### PR TITLE
add managed acct endpoints

### DIFF
--- a/collections/binance_spot_api_v1.postman_collection.json
+++ b/collections/binance_spot_api_v1.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "83362713-d0fc-4de4-97e6-57e4b21a40b0",
+		"_postman_id": "44e37af4-0b19-4bc0-9078-eea5d6f47a47",
 		"name": "Binance spot API",
 		"description": "Binance official supported Postman collections.<br/>\n- API documents: https://binance-docs.github.io/apidocs/spot/en/#change-log\n- Telegram: https://t.me/binance_api_english\n- Open Issue at: https://github.com/binance-exchange/binance-api-postman",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
@@ -2096,6 +2096,164 @@
 									"key": "recvWindow",
 									"value": "",
 									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Deposit assets into the managed sub-account（For Investor Master Account）",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"type": "text",
+								"value": "{{binance-api-key}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/managed-subaccount/deposit?toEmail=&asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"managed-subaccount",
+								"deposit"
+							],
+							"query": [
+								{
+									"key": "toEmail",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "asset",
+									"value": ""
+								},
+								{
+									"key": "amount",
+									"value": ""
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Query managed sub-account asset details（For Investor Master Account）",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"type": "text",
+								"value": "{{binance-api-key}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/managed-subaccount/asset?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"managed-subaccount",
+								"asset"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Withdrawl assets from the managed sub-account（For Investor Master Account）",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"type": "text",
+								"value": "{{binance-api-key}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/managed-subaccount/withdraw?fromEmail=&asset=&amount=&transferDate=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"managed-subaccount",
+								"withdraw"
+							],
+							"query": [
+								{
+									"key": "fromEmail",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "asset",
+									"value": ""
+								},
+								{
+									"key": "amount",
+									"value": ""
+								},
+								{
+									"key": "transferDate",
+									"value": ""
 								},
 								{
 									"key": "timestamp",


### PR DESCRIPTION
New endpoints for Sub-Account:
- POST /sapi/v1/managed-subaccount/deposit to deposit assets into the managed sub-account (only for investor master account)
- GET /sapi/v1/managed-subaccount/asset to query managed sub-account asset details (only for investor master account)
- POST /sapi/v1/managed-subaccount/withdraw to withdrawl assets from the managed sub-account (only for investor master account)
