### PR TITLE
Fix URL for Futures symbol price ticker

### DIFF
--- a/collections/binance_perpetual_future_api_v1.postman_collection.json
+++ b/collections/binance_perpetual_future_api_v1.postman_collection.json
@@ -600,7 +600,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/fapi/v1/ticker/24hr",
+							"raw": "{{url}}/fapi/v1/ticker/price",
 							"host": [
 								"{{url}}"
 							],


### PR DESCRIPTION
Current `Futures symbol price ticker` URL is equal to `24hr ticker price change statistics`