### PR TITLE
Removed limit from Margin Interest Rate History

### DIFF
--- a/collections/binance_spot_api_v1.postman_collection.json
+++ b/collections/binance_spot_api_v1.postman_collection.json
@@ -8172,12 +8172,6 @@
 									"disabled": true
 								},
 								{
-									"key": "limit",
-									"value": "",
-									"description": "Default: 20. Maximum: 100",
-									"disabled": true
-								},
-								{
 									"key": "recvWindow",
 									"value": "",
 									"description": "No more than 60000"


### PR DESCRIPTION
Update endpoint for Margin：

- Removed out limit from GET /sapi/v1/margin/interestRateHistory