### PR TITLE
1.1.0

### DIFF
--- a/collections/binance_broker_api_v1.postman_collection.json
+++ b/collections/binance_broker_api_v1.postman_collection.json
@@ -40,6 +40,12 @@
 							"description": "tag length should be less than 32"
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -91,6 +97,12 @@
 							"description": "only true for now"
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -140,6 +152,12 @@
 							"key": "futures",
 							"value": "",
 							"description": "only true for now"
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
 						},
 						{
 							"key": "timestamp",
@@ -201,6 +219,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -248,6 +272,12 @@
 						{
 							"key": "subAccountApiKey",
 							"value": ""
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
 						},
 						{
 							"key": "timestamp",
@@ -312,6 +342,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -373,6 +409,12 @@
 							"value": ""
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -428,6 +470,12 @@
 							"key": "size",
 							"value": null,
 							"description": "default 500",
+							"disabled": true
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
 							"disabled": true
 						},
 						{
@@ -495,6 +543,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -554,6 +608,12 @@
 							"value": ""
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -606,6 +666,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -646,6 +712,12 @@
 						"info"
 					],
 					"query": [
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
 						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
@@ -709,6 +781,12 @@
 						{
 							"key": "amount",
 							"value": ""
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
 						},
 						{
 							"key": "timestamp",
@@ -792,6 +870,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -856,6 +940,12 @@
 							"description": "default 500, max 500"
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -910,6 +1000,12 @@
 						{
 							"key": "endTime",
 							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
 							"disabled": true
 						},
 						{
@@ -975,6 +1071,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -1024,6 +1126,12 @@
 						{
 							"key": "spotBNBBurn",
 							"value": ""
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
 						},
 						{
 							"key": "timestamp",
@@ -1077,6 +1185,12 @@
 							"value": ""
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -1122,6 +1236,12 @@
 						{
 							"key": "subAccountId",
 							"value": ""
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
 						},
 						{
 							"key": "timestamp",
@@ -1201,6 +1321,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -1255,6 +1381,12 @@
 						{
 							"key": "size",
 							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
 							"disabled": true
 						},
 						{
@@ -1315,6 +1447,12 @@
 							"disabled": true
 						},
 						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
+							"disabled": true
+						},
+						{
 							"key": "timestamp",
 							"value": "{{timestamp}}"
 						},
@@ -1369,6 +1507,12 @@
 						{
 							"key": "size",
 							"value": "",
+							"disabled": true
+						},
+						{
+							"key": "recvWindow",
+							"value": "5000",
+							"description": "The value cannot be greater than 60000",
 							"disabled": true
 						},
 						{

--- a/collections/binance_delivery_future_api_v1.postman_collection.json
+++ b/collections/binance_delivery_future_api_v1.postman_collection.json
@@ -1082,6 +1082,12 @@
 									"description": "Boolean value. \"true\": Hedge Mode mode; \"false\": One-way Mode"
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1134,6 +1140,12 @@
 								"dual"
 							],
 							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
 								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
@@ -1266,6 +1278,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1349,6 +1367,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1404,6 +1428,12 @@
 								{
 									"key": "batchOrders",
 									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -1462,6 +1492,12 @@
 									"key": "batchOrders",
 									"value": "",
 									"description": "order list. Max 5 orders"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -1548,6 +1584,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1610,6 +1652,12 @@
 								{
 									"key": "origClientOrderId",
 									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -1678,6 +1726,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1732,6 +1786,12 @@
 								{
 									"key": "symbol",
 									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -1800,6 +1860,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1859,6 +1925,12 @@
 									"key": "countdownTime",
 									"value": "",
 									"description": "countdown time, 1000 for 1 second. 0 to cancel the timer"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -1926,6 +1998,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1985,6 +2063,12 @@
 								{
 									"key": "pair",
 									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -2071,6 +2155,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2122,6 +2212,12 @@
 								"account"
 							],
 							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
 								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
@@ -2183,6 +2279,12 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2241,6 +2343,12 @@
 								{
 									"key": "marginType",
 									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -2311,6 +2419,12 @@
 								{
 									"key": "type",
 									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -2390,6 +2504,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2449,6 +2569,12 @@
 								{
 									"key": "pair",
 									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -2534,6 +2660,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2611,6 +2743,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2665,6 +2803,12 @@
 								{
 									"key": "pair",
 									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -2747,6 +2891,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2801,6 +2951,12 @@
 								{
 									"key": "symbol",
 									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{

--- a/collections/binance_perpetual_future_api_v1.postman_collection.json
+++ b/collections/binance_perpetual_future_api_v1.postman_collection.json
@@ -1217,6 +1217,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1354,6 +1360,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1455,6 +1467,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1513,6 +1531,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1567,6 +1591,12 @@
 								{
 									"key": "symbol",
 									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -1806,6 +1836,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1861,6 +1897,12 @@
 								{
 									"key": "batchOrders",
 									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -1930,6 +1972,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1996,6 +2044,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2050,6 +2104,12 @@
 								{
 									"key": "symbol",
 									"value": "BTCUSDT"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -2111,6 +2171,12 @@
 									"key": "countdownTime",
 									"value": "",
 									"description": "countdown time, 1000 for 1 second. 0 to cancel the timer"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -2179,6 +2245,12 @@
 									"value": "[IKDQAMirf7vElig8hTZHh0,HwJSQKA7drF37tqqAN6q6q]"
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2233,6 +2305,12 @@
 								{
 									"key": "symbol",
 									"value": "BTCUSDT",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -2299,6 +2377,12 @@
 								{
 									"key": "origClientOrderId",
 									"value": null,
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -2379,6 +2463,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2456,6 +2546,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2521,6 +2617,12 @@
 									"value": "ISOLATED"
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2579,6 +2681,12 @@
 								{
 									"key": "leverage",
 									"value": "20"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -2649,6 +2757,12 @@
 								{
 									"key": "type",
 									"value": "1"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -2728,6 +2842,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2786,6 +2906,12 @@
 									"description": "Boolean value. \"true\": Hedge Mode mode; \"false\": One-way Mode"
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -2838,6 +2964,12 @@
 								"dual"
 							],
 							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
 								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
@@ -2893,6 +3025,12 @@
 								{
 									"key": "symbol",
 									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{

--- a/collections/binance_spot_api_v1.postman_collection.json
+++ b/collections/binance_spot_api_v1.postman_collection.json
@@ -7,10 +7,10 @@
 	},
 	"item": [
 		{
-			"name": "Blvt",
+			"name": "BLVT",
 			"item": [
 				{
-					"name": "Leverage token info",
+					"name": "Get BLVT Info (MARKET_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -40,15 +40,17 @@
 								{
 									"key": "tokenName",
 									"value": "",
+									"description": "BTCDOWN, BTCUP",
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Subscribe BLVT",
+					"name": "Subscribe BLVT (USER_DATA)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -59,8 +61,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -77,27 +79,38 @@
 							"query": [
 								{
 									"key": "tokenName",
-									"value": ""
+									"value": "",
+									"description": "BTCDOWN, BTCUP"
 								},
 								{
 									"key": "cost",
-									"value": ""
+									"value": "",
+									"description": "Spot balance"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Query Subscription Record",
+					"name": "Query Subscription Record (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -108,8 +121,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -128,6 +141,7 @@
 								{
 									"key": "tokenName",
 									"value": "",
+									"description": "BTCDOWN, BTCUP",
 									"disabled": true
 								},
 								{
@@ -138,34 +152,45 @@
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": "1000",
-									"description": "default  1000 ， max1000",
+									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- Only the data of the latest 90 days is available\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Redeem BLVT",
+					"name": "Redeem BLVT (USER_DATA)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -176,12 +201,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/blvt/redeem?tokenName=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/blvt/redeem?tokenName=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -194,27 +219,37 @@
 							"query": [
 								{
 									"key": "tokenName",
-									"value": ""
+									"value": "",
+									"description": "BTCDOWN, BTCUP"
 								},
 								{
 									"key": "amount",
-									"value": ""
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Query Redemption Record",
+					"name": "Query Redemption Record (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -225,8 +260,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -245,6 +280,7 @@
 								{
 									"key": "tokenName",
 									"value": "",
+									"description": "BTCDOWN, BTCUP",
 									"disabled": true
 								},
 								{
@@ -255,34 +291,45 @@
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "",
-									"description": "default  1000 ， max1000",
+									"description": "default 1000, max 1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- Only the data of the latest 90 days is available\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Get BLVT User Limit Info",
+					"name": "Get BLVT User Limit Info (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -293,8 +340,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -312,29 +359,38 @@
 								{
 									"key": "tokenName",
 									"value": "",
+									"description": "BTCDOWN, BTCUP",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
-				}
-			],
-			"description": "Leverage token"
+				}],
+			"description": "Binance Leveraged Tokens Endpoints"
 		},
-		{
-			"name": "Bswap",
+			{
+			"name": "BSwap",
 			"item": [
 				{
-					"name": "List All Swap Pools",
+					"name": "List All Swap Pools (MARKET_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -345,8 +401,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -360,7 +416,8 @@
 								"bswap",
 								"pools"
 							]
-						}
+						},
+						"description": "Get metadata about all swap pools.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -376,8 +433,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -398,15 +455,24 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get liquidity information and user share of a pool.\n\nWeight(IP):\n- `1` for one pool;\n- `10` when the poolId parameter is omitted;"
 					},
 					"response": []
 				},
@@ -422,12 +488,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/liquidityAdd?poolId=&asset=&quantity=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/bswap/liquidityAdd?poolId=&asset=BTC&quantity=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -443,23 +509,38 @@
 									"value": ""
 								},
 								{
+									"key": "type",
+									"value": "Single",
+									"description": "* `Single` - to add a single token\n* `Combination` - to add dual tokens",
+									"disabled": true
+								},
+								{
 									"key": "asset",
-									"value": ""
+									"value": "BTC"
 								},
 								{
 									"key": "quantity",
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Add liquidity to a pool.\n\nWeight(UID): 1000 (Additional: 3 times one second)"
 					},
 					"response": []
 				},
@@ -475,12 +556,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/liquidityRemove?poolId=&type=&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/bswap/liquidityRemove?poolId=&type=SINGLE&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -497,12 +578,13 @@
 								},
 								{
 									"key": "type",
-									"value": "",
-									"description": "SINGLE for single asset removal, COMBINATION for combination of all coins removal"
+									"value": "SINGLE",
+									"description": "* `SINGLE` - for single asset removal\n* `COMBINATION` - for combination of all coins removal"
 								},
 								{
 									"key": "asset",
-									"value": "",
+									"value": "BNB",
+									"description": "Mandatory for single asset removal",
 									"disabled": true
 								},
 								{
@@ -510,15 +592,24 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Remove liquidity from a pool, `type` include `SINGLE` and `COMBINATION`, asset is mandatory for single asset removal\n\nWeight(UID): 1000 (Additional: 3 times one second)"
 					},
 					"response": []
 				},
@@ -534,8 +625,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -568,28 +659,40 @@
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "limit",
-									"value": "",
+									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get liquidity operation (add/remove) records.\n\nWeight(UID): 3000"
 					},
 					"response": []
 				},
@@ -605,12 +708,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/quote?quoteAsset=&baseAsset=&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/bswap/quote?quoteAsset=USDT&baseAsset=BUSD&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -623,26 +726,35 @@
 							"query": [
 								{
 									"key": "quoteAsset",
-									"value": ""
+									"value": "USDT"
 								},
 								{
 									"key": "baseAsset",
-									"value": ""
+									"value": "BUSD"
 								},
 								{
 									"key": "quoteQty",
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Request a quote for swap quote asset (selling asset) for base asset (buying asset), essentially price/exchange rates.\n\nquoteQty is quantity of quote asset (to sell).\n\nPlease be noted the quote is for reference only, the actual price will change as the liquidity changes, it's recommended to swap immediate after request a quote for slippage prevention.\n\nWeight(UID): 150"
 					},
 					"response": []
 				},
@@ -658,12 +770,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/swap?quoteAsset=&baseAsset=&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/bswap/swap?quoteAsset=USDT&baseAsset=BUSD&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -676,26 +788,35 @@
 							"query": [
 								{
 									"key": "quoteAsset",
-									"value": ""
+									"value": "USDT"
 								},
 								{
 									"key": "baseAsset",
-									"value": ""
+									"value": "BUSD"
 								},
 								{
 									"key": "quoteQty",
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Swap `quoteAsset` for `baseAsset`.\n\nWeight(UID): 1000 (Additional: 3 times one second)"
 					},
 					"response": []
 				},
@@ -711,8 +832,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -735,44 +856,56 @@
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "status",
 									"value": "",
-									"description": "0: pending for swap, 1: success, 2: failed",
+									"description": "* `0` - pending for swap\n* `1` - success\n* `2` - failed",
 									"disabled": true
 								},
 								{
 									"key": "quoteAsset",
-									"value": "",
+									"value": "USDT",
 									"disabled": true
 								},
 								{
 									"key": "baseAsset",
-									"value": "",
+									"value": "BUSD",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "",
+									"description": "default 3, max 100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get swap history.\n\nWeight(UID): 3000"
 					},
 					"response": []
 				},
@@ -788,8 +921,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -806,19 +939,28 @@
 							"query": [
 								{
 									"key": "poolId",
-									"value": "",
+									"value": "2",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 150"
 					},
 					"response": []
 				},
@@ -834,12 +976,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/addLiquidityPreview?poolId=&type=&quoteAsset=&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/bswap/addLiquidityPreview?poolId=2&type=SINGLE&quoteAsset=USDT&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -852,31 +994,40 @@
 							"query": [
 								{
 									"key": "poolId",
-									"value": ""
+									"value": "2"
 								},
 								{
 									"key": "type",
-									"value": "",
-									"description": "\"SINGLE\" for adding a single token;\"COMBINATION\" for adding dual tokens"
+									"value": "SINGLE",
+									"description": "* `SINGLE` - for adding a single token\n* `COMBINATION` - for adding dual tokens"
 								},
 								{
 									"key": "quoteAsset",
-									"value": ""
+									"value": "USDT"
 								},
 								{
 									"key": "quoteQty",
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Calculate expected share amount for adding liquidity in single or dual token.\n\nWeight(IP): 150"
 					},
 					"response": []
 				},
@@ -892,12 +1043,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/removeLiquidityPreview?poolId=&type=&quoteAsset=&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/bswap/removeLiquidityPreview?poolId=2&type=SINGLE&quoteAsset=USDT&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -910,31 +1061,40 @@
 							"query": [
 								{
 									"key": "poolId",
-									"value": ""
+									"value": "2"
 								},
 								{
 									"key": "type",
-									"value": "",
-									"description": "Type is \"SINGLE\", remove and obtain a single token;Type is \"COMBINATION\", remove and obtain dual token."
+									"value": "SINGLE",
+									"description": "* `SINGLE` - remove and obtain a single token\n* `COMBINATION` - remove and obtain dual token"
 								},
 								{
 									"key": "quoteAsset",
-									"value": ""
+									"value": "USDT"
 								},
 								{
 									"key": "shareAmount",
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Calculate the expected asset amount of single token redemption or dual token redemption.\n\nWeight(IP): 150"
 					},
 					"response": []
 				},
@@ -950,8 +1110,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -968,25 +1128,34 @@
 							"query": [
 								{
 									"key": "type",
-									"value": "",
-									"description": "0: Swap rewards,1:Liquidity rewards, default to 0",
+									"value": "0",
+									"description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get unclaimed rewards record.\n \nWeight(UID): 1000"
 					},
 					"response": []
 				},
 				{
-					"name": "Claim rewards (TRADE)",
+					"name": "Claim Rewards (TRADE)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -997,8 +1166,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -1015,20 +1184,29 @@
 							"query": [
 								{
 									"key": "type",
-									"value": "",
-									"description": "0: Swap rewards,1:Liquidity rewards, default to 0",
+									"value": "0",
+									"description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Claim swap rewards or liquidity rewards\n \nWeight(UID): 1000"
 					},
 					"response": []
 				},
@@ -1044,8 +1222,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -1072,18 +1250,20 @@
 								},
 								{
 									"key": "type",
-									"value": "",
-									"description": "0: Swap rewards,1:Liquidity rewards, default to 0",
+									"value": "0",
+									"description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
@@ -1093,21 +1273,30 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get history of claimed rewards.\n \nWeight(UID): 1000"
 					},
 					"response": []
-				}
-			]
+				}],
+			"description": "Binance Swap Endpoints"
 		},
-		{
+			{
 			"name": "C2C",
 			"item": [
 				{
@@ -1122,12 +1311,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/c2c/orderMatch/listUserOrderHistory?tradeType=BUY&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/c2c/orderMatch/listUserOrderHistory?tradeType=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -1141,23 +1330,24 @@
 							"query": [
 								{
 									"key": "tradeType",
-									"value": "BUY",
-									"description": "BUY, SELL"
+									"value": ""
 								},
 								{
 									"key": "startTimestamp",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTimestamp",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "page",
-									"value": "",
-									"description": "default 1",
+									"value": "1",
+									"description": "Default 1",
 									"disabled": true
 								},
 								{
@@ -1167,1971 +1357,30 @@
 									"disabled": true
 								},
 								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Corporate ( sub-account )",
-			"item": [
-				{
-					"name": "Create a Virtual Sub-account(For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/virtualSubAccount?subAccountString=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"virtualSubAccount"
-							],
-							"query": [
-								{
-									"key": "subAccountString",
-									"value": "",
-									"description": "Please input a string. We will create a virtual email using that string for you to register"
-								},
-								{
 									"key": "recvWindow",
-									"value": "",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account List SAPI(For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/list?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"list"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "isFreeze",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Spot Asset Transfer History(For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/sub/transfer/history?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"sub",
-								"transfer",
-								"history"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "toEmail",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Futures Asset Transfer History(For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?email&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"internalTransfer"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": null
-								},
-								{
-									"key": "futuresType",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "default 1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 50, max 500",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Sub-account Futures Asset Transfer(For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?fromEmail&toEmail&futuresType&asset&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"internalTransfer"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": null
-								},
-								{
-									"key": "toEmail",
-									"value": null
-								},
-								{
-									"key": "futuresType",
-									"value": null,
-									"description": "1:USDT-margined Futures，2: Coin-margined Futures"
-								},
-								{
-									"key": "asset",
-									"value": null
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Assets(SAPI) (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v3/sub-account/assets?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v3",
-								"sub-account",
-								"assets"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Spot Assets Summary (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/spotSummary?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"spotSummary"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "default 1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "",
-									"description": "default 10, max 20",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
 						},
-						"description": "Get BTC valued asset summary of subaccouts."
+						"description": "- If startTimestamp and endTimestamp are not sent, the recent 30-day data will be returned.\n- The max interval between startTimestamp and endTimestamp is 30 days.\n\nWeight(IP): 1"
 					},
 					"response": []
-				},
-				{
-					"name": "Get Sub-account Deposit Address (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/subAddress?email&coin&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"subAddress"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": null,
-									"description": "Sub account email"
-								},
-								{
-									"key": "coin",
-									"value": null
-								},
-								{
-									"key": "network",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Sub-account Deposit History (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/subHisrec?email&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"subHisrec"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": null,
-									"description": "Sub account email"
-								},
-								{
-									"key": "coin",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "status",
-									"value": null,
-									"description": "0(0:pending, 6:credited but cannot withdraw, 1:success)",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "offset",
-									"value": null,
-									"description": "default:0",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Sub-account's Status on Margin/Futures(For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/status?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"status"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Margin for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/enable?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"enable"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Detail on Sub-account's Margin Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/account?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"account"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Summary of Sub-account's Margin Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"accountSummary"
-							],
-							"query": [
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Futures for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/enable?email&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"enable"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": null
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Detail on Sub-account's Futures Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/account?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"account"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Summary of Sub-account's Futures Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"accountSummary"
-							],
-							"query": [
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Futures Postion-Risk of Sub-account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/positionRisk?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"positionRisk"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Futures Transfer for Sub-account（For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/transfer?email=&asset&amount&type&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "asset",
-									"value": null
-								},
-								{
-									"key": "amount",
-									"value": null
-								},
-								{
-									"key": "type",
-									"value": null
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Transfer for Sub-account（For Master Account",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/transfer?email=&asset&amount&type&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "asset",
-									"value": null
-								},
-								{
-									"key": "amount",
-									"value": null
-								},
-								{
-									"key": "type",
-									"value": null
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Transfer to Sub-account of Same Master（For Sub-account）",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/transfer/subToSub?toEmail=&asset&amount&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"transfer",
-								"subToSub"
-							],
-							"query": [
-								{
-									"key": "toEmail",
-									"value": ""
-								},
-								{
-									"key": "asset",
-									"value": null
-								},
-								{
-									"key": "amount",
-									"value": null
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Transfer to Master（For Sub-account）",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/transfer/subToMaster?asset&amount&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"transfer",
-								"subToMaster"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": null
-								},
-								{
-									"key": "amount",
-									"value": null
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Sub-account Transfer History (For Sub-account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/transfer/subUserHistory?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"transfer",
-								"subUserHistory"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "type",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Universal Transfer (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/universalTransfer?fromAccountType=&toAccountType=&asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"universalTransfer"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "toEmail",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "fromAccountType",
-									"value": "",
-									"description": "\"SPOT\",\"USDT_FUTURE\",\"COIN_FUTURE\""
-								},
-								{
-									"key": "toAccountType",
-									"value": "",
-									"description": "\"SPOT\",\"USDT_FUTURE\",\"COIN_FUTURE\""
-								},
-								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Universal Transfer History",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/universalTransfer?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"universalTransfer"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "toEmail",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Leverage Token for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/blvt/enable?email=&enableBlvt=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"blvt",
-								"enable"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "enableBlvt",
-									"value": "",
-									"description": "Only true for now"
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Enable or Disable IP Restriction for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&ipRestrict&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "ipRestrict",
-									"value": null,
-									"description": "true or false"
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Add IP List for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction",
-								"ipList"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "ipAddress",
-									"value": null,
-									"description": "Can be added in batches, separated by commas"
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get IP Restriction for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Delete IP List for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction",
-								"ipList"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "ipAddress",
-									"value": null,
-									"description": "Can be added in batches, separated by commas"
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Deposit assets into the managed sub-account（For Investor Master Account）",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/managed-subaccount/deposit?toEmail=&asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"managed-subaccount",
-								"deposit"
-							],
-							"query": [
-								{
-									"key": "toEmail",
-									"value": ""
-								},
-								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query managed sub-account asset details（For Investor Master Account）",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/managed-subaccount/asset?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"managed-subaccount",
-								"asset"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Withdrawl assets from the managed sub-account（For Investor Master Account）",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/managed-subaccount/withdraw?fromEmail=&asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"managed-subaccount",
-								"withdraw"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": ""
-								},
-								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "transferDate",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
+				}],
+			"description": "Consumer-To-Consumer Endpoints"
 		},
-		{
-			"name": "Crypto Loans",
-			"item": [
-				{
-					"name": "Get Crypto Loans Income History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/loan/income?asset=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"loan",
-								"income"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "type",
-									"value": null,
-									"description": "All types will be returned by default. Enum：borrowIn ,collateralSpent, repayAmount, collateralReturn, addCollateral, removeCollateral, collateralReturnAfterLiquidation",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 20, max 100",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Pay",
-			"item": [
-				{
-					"name": "Get Pay Trade History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/pay/transactions?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"pay",
-								"transactions"
-							],
-							"query": [
-								{
-									"key": "startTimestamp",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTimestamp",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 100, max 100",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
+			{
 			"name": "Convert",
 			"item": [
 				{
@@ -3146,8 +1395,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -3164,700 +1413,128 @@
 							"query": [
 								{
 									"key": "startTime",
-									"value": null
-								},
-								{
-									"key": "endTime",
-									"value": null
-								},
-								{
-									"key": "limit",
 									"value": "",
-									"description": "Default 100, Max 1000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Rebate",
-			"item": [
-				{
-					"name": "Get Spot Rebate History Records (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/rebate/taxQuery?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"rebate",
-								"taxQuery"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "NFT",
-			"item": [
-				{
-					"name": "Get NFT Transaction History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/history/transactions?orderType=0&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"history",
-								"transactions"
-							],
-							"query": [
-								{
-									"key": "orderType",
-									"value": "0",
-									"description": "0: purchase order, 1: sell order, 2: royalty income, 3: primary market order, 4: mint fee"
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "endTime",
 									"value": "",
-									"disabled": true
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "limit",
-									"value": null,
-									"description": "Default 50, Max 50",
+									"value": "100",
+									"description": "default 100, max 1000",
 									"disabled": true
 								},
 								{
-									"key": "page",
-									"value": "",
-									"description": "Default 1",
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get NFT Deposit History(USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/history/deposit?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"history",
-								"deposit"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": null,
-									"description": "Default 50, Max 50",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get NFT Withdraw History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/history/withdraw?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"history",
-								"withdraw"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": null,
-									"description": "Default 50, Max 50",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get NFT Asset (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/user/getAsset?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"user",
-								"getAsset"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": null,
-									"description": "Default 50, Max 50",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
-		},
-		{
-			"name": "Data Stream",
-			"item": [
-				{
-					"name": "Spot",
-					"item": [
-						{
-							"name": "Create New Listen Key",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/api/v3/userDataStream",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v3",
-										"userDataStream"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Renew Listen Key",
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/api/v3/userDataStream?listenKey=",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v3",
-										"userDataStream"
-									],
-									"query": [
-										{
-											"key": "listenKey",
-											"value": ""
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Delete Listen Key",
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/api/v3/userDataStream?listenKey=",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v3",
-										"userDataStream"
-									],
-									"query": [
-										{
-											"key": "listenKey",
-											"value": ""
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					]
-				},
-				{
-					"name": "Margin",
-					"item": [
-						{
-							"name": "isolated",
-							"item": [
-								{
-									"name": "Create New Isolated Margin Account Listen Key",
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "X-MBX-APIKEY",
-												"type": "text",
-												"value": "{{binance-api-key}}"
-											}
-										],
-										"url": {
-											"raw": "{{url}}/sapi/v1/userDataStream/isolated?symbol=BTCUSDT",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"sapi",
-												"v1",
-												"userDataStream",
-												"isolated"
-											],
-											"query": [
-												{
-													"key": "symbol",
-													"value": "BTCUSDT"
-												}
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Renew Isolated Margin Account Listen Key",
-									"request": {
-										"method": "PUT",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "X-MBX-APIKEY",
-												"type": "text",
-												"value": "{{binance-api-key}}"
-											}
-										],
-										"url": {
-											"raw": "{{url}}/sapi/v1/userDataStream/isolated?listenKey=&symbol=",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"sapi",
-												"v1",
-												"userDataStream",
-												"isolated"
-											],
-											"query": [
-												{
-													"key": "listenKey",
-													"value": ""
-												},
-												{
-													"key": "symbol",
-													"value": ""
-												}
-											]
-										}
-									},
-									"response": []
-								},
-								{
-									"name": "Delete Isolated Margin Account Listen Key",
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "X-MBX-APIKEY",
-												"type": "text",
-												"value": "{{binance-api-key}}"
-											}
-										],
-										"url": {
-											"raw": "{{url}}/sapi/v1/userDataStream/isolated?listenKey=&symbol",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"sapi",
-												"v1",
-												"userDataStream",
-												"isolated"
-											],
-											"query": [
-												{
-													"key": "listenKey",
-													"value": ""
-												},
-												{
-													"key": "symbol",
-													"value": null
-												}
-											]
-										}
-									},
-									"response": []
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
 						},
-						{
-							"name": "cross",
-							"item": [
+						"description": "- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 3000"
+					},
+					"response": []
+				}],
+			"description": "Convert Endpoints"
+		},
+			{
+			"name": "Crypto Loans",
+			"item": [
+				{
+					"name": "Get Crypto Loans Income History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/loan/income?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"loan",
+								"income"
+							],
+							"query": [
 								{
-									"name": "Create New Listen Key",
-									"request": {
-										"method": "POST",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "X-MBX-APIKEY",
-												"type": "text",
-												"value": "{{binance-api-key}}"
-											}
-										],
-										"url": {
-											"raw": "{{url}}/sapi/v1/userDataStream",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"sapi",
-												"v1",
-												"userDataStream"
-											]
-										}
-									},
-									"response": []
+									"key": "asset",
+									"value": "BTC"
 								},
 								{
-									"name": "Renew Listen Key",
-									"request": {
-										"method": "PUT",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "X-MBX-APIKEY",
-												"type": "text",
-												"value": "{{binance-api-key}}"
-											}
-										],
-										"url": {
-											"raw": "{{url}}/sapi/v1/userDataStream?listenKey=",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"sapi",
-												"v1",
-												"userDataStream"
-											],
-											"query": [
-												{
-													"key": "listenKey",
-													"value": ""
-												}
-											]
-										}
-									},
-									"response": []
+									"key": "type",
+									"value": "",
+									"description": "All types will be returned by default.\n* `borrowIn`\n* `collateralSpent`\n* `repayAmount`\n* `collateralReturn` - Collateral return after repayment\n* `addCollateral`\n* `removeCollateral`\n* `collateralReturnAfterLiquidation`",
+									"disabled": true
 								},
 								{
-									"name": "Delete Listen Key",
-									"request": {
-										"method": "DELETE",
-										"header": [
-											{
-												"key": "Content-Type",
-												"type": "text",
-												"value": "application/json"
-											},
-											{
-												"key": "X-MBX-APIKEY",
-												"type": "text",
-												"value": "{{binance-api-key}}"
-											}
-										],
-										"url": {
-											"raw": "{{url}}/sapi/v1/userDataStream?listenKey=",
-											"host": [
-												"{{url}}"
-											],
-											"path": [
-												"sapi",
-												"v1",
-												"userDataStream"
-											],
-											"query": [
-												{
-													"key": "listenKey",
-													"value": ""
-												}
-											]
-										}
-									},
-									"response": []
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "20",
+									"description": "default 20, max 100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
-					]
-				}
-			]
+						},
+						"description": "- If startTime and endTime are not sent, the recent 7-day data will be returned.\n- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 6000"
+					},
+					"response": []
+				}],
+			"description": "Crypto Loans Endpoints"
 		},
-		{
+			{
 			"name": "Fiat",
 			"item": [
 				{
@@ -3872,8 +1549,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -3891,40 +1568,50 @@
 								{
 									"key": "transactionType",
 									"value": "0",
-									"description": "0-deposit,1-withdraw"
+									"description": "* `0` - deposit\n* `1` - withdraw"
 								},
 								{
 									"key": "beginTime",
-									"value": "",
+									"value": "1626144956000",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "page",
-									"value": null,
-									"description": "default 1",
+									"value": "1",
+									"description": "Default 1",
 									"disabled": true
 								},
 								{
 									"key": "rows",
-									"value": null,
-									"description": "default 100, max 500",
+									"value": "300",
+									"description": "Default 100, max 500",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -3940,8 +1627,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -3959,50 +1646,60 @@
 								{
 									"key": "transactionType",
 									"value": "0",
-									"description": "0-deposit,1-withdraw"
+									"description": "* `0` - deposit\n* `1` - withdraw"
 								},
 								{
 									"key": "beginTime",
-									"value": "",
+									"value": "1626144956000",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "page",
-									"value": null,
-									"description": "default 1",
+									"value": "1",
+									"description": "Default 1",
 									"disabled": true
 								},
 								{
 									"key": "rows",
-									"value": null,
-									"description": "default 100, max 500",
+									"value": "300",
+									"description": "Default 100, max 500",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
 					},
 					"response": []
-				}
-			]
+				}],
+			"description": "Fiat Endpoints"
 		},
-		{
+			{
 			"name": "Futures",
 			"item": [
 				{
-					"name": "New Future Account Transfer",
+					"name": "New Future Account Transfer (USER_DATA)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -4013,8 +1710,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4031,32 +1728,43 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": ""
+									"value": "",
+									"description": "The asset being transferred, e.g., USDT"
 								},
 								{
 									"key": "amount",
-									"value": ""
+									"value": "",
+									"description": "The amount to be transferred"
 								},
 								{
 									"key": "type",
 									"value": "",
-									"description": "1: transfer from spot main account to future account 2: transfer from future account to spot main account"
+									"description": "1: transfer from spot account to USDT-Ⓜ futures account. 2: transfer from USDT-Ⓜ futures account to spot account. 3: transfer from spot account to COIN-Ⓜ futures account. 4: transfer from COIN-Ⓜ futures account to spot account."
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Execute transfer between spot account and futures account.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Get Future Account Transaction History List",
+					"name": "Get Future Account Transaction History List (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -4067,12 +1775,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/futures/transfer?asset=&startTime&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/futures/transfer?asset=&startTime=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -4089,16 +1797,17 @@
 								},
 								{
 									"key": "startTime",
-									"value": null
+									"value": ""
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "current",
 									"value": "",
+									"description": "Currently querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
@@ -4108,15 +1817,24 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 10"
 					},
 					"response": []
 				},
@@ -4132,12 +1850,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/borrow?coin=&amount=&collateralCoin=&collateralAmount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/futures/loan/borrow?coin=&collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -4155,7 +1873,8 @@
 								},
 								{
 									"key": "amount",
-									"value": ""
+									"value": "",
+									"disabled": true
 								},
 								{
 									"key": "collateralCoin",
@@ -4163,19 +1882,28 @@
 								},
 								{
 									"key": "collateralAmount",
-									"value": ""
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
 						},
-						"description": "limit: once per second per account"
+						"description": ""
 					},
 					"response": []
 				},
@@ -4191,8 +1919,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4227,18 +1955,28 @@
 								{
 									"key": "limit",
 									"value": "",
+									"description": "default 500, max 1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4254,8 +1992,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4284,16 +2022,24 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
 						},
-						"description": "limit: once per second per account"
+						"description": ""
 					},
 					"response": []
 				},
@@ -4309,8 +2055,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4345,18 +2091,28 @@
 								{
 									"key": "limit",
 									"value": "",
+									"description": "default 500, max 1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4372,8 +2128,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4390,15 +2146,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4414,8 +2179,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4432,15 +2197,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4456,8 +2230,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4479,15 +2253,24 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4503,8 +2286,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4531,15 +2314,24 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4555,8 +2347,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4586,15 +2378,24 @@
 									"description": "\"ADDITIONAL\", \"REDUCED\""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4610,8 +2411,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4645,15 +2446,24 @@
 									"description": "\"ADDITIONAL\", \"REDUCED\""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4669,8 +2479,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4691,15 +2501,24 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4715,8 +2534,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4741,15 +2560,24 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4765,8 +2593,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4796,15 +2624,24 @@
 									"description": "\"ADDITIONAL\", \"REDUCED\""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4820,8 +2657,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4855,15 +2692,24 @@
 									"description": "\"ADDITIONAL\", \"REDUCED\""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4879,8 +2725,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4920,18 +2766,28 @@
 								{
 									"key": "limit",
 									"value": "",
+									"description": "default 500, max 1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -4947,8 +2803,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -4987,18 +2843,28 @@
 								{
 									"key": "limit",
 									"value": "",
+									"description": "default 500, max 1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
 				},
@@ -5014,8 +2880,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -5040,15 +2906,24 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Check the maximum and minimum limit when repay with collateral."
 					},
 					"response": []
 				},
@@ -5064,8 +2939,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -5091,18 +2966,28 @@
 								},
 								{
 									"key": "amount",
-									"value": ""
+									"value": "",
+									"description": "repay amount"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds."
 					},
 					"response": []
 				},
@@ -5118,8 +3003,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -5140,15 +3025,24 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Repay with collateral. Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds."
 					},
 					"response": []
 				},
@@ -5164,8 +3058,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -5186,15 +3080,24 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Check collateral repayment result."
 					},
 					"response": []
 				},
@@ -5210,8 +3113,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -5245,162 +3148,44 @@
 								{
 									"key": "current",
 									"value": "",
+									"description": "Currently querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "",
+									"description": "Default:500 Max:1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": ""
 					},
 					"response": []
-				}
-			]
+				}],
+			"description": ""
 		},
-		{
-			"name": "Wallet",
+			{
+			"name": "Futures Algo",
 			"item": [
 				{
-					"name": "System Status (System)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/system/status",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"system",
-								"status"
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "All Coins' Information (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/config/getall?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"config",
-								"getall"
-							],
-							"query": [
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Daily Account Snapshot (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/accountSnapshot?type=SPOT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"accountSnapshot"
-							],
-							"query": [
-								{
-									"key": "type",
-									"value": "SPOT",
-									"description": "\"SPOT\", \"MARGIN\", \"FUTURES\""
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "5",
-									"description": "min 5, max 30, default 5",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Disable Fast Withdraw Switch (USER_DATA)",
+					"name": "Volume Participation New Order (TRADE)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -5411,730 +3196,93 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/disableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"disableFastWithdrawSwitch"
-							],
-							"query": [
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Fast Withdraw Switch (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/enableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"enableFastWithdrawSwitch"
-							],
-							"query": [
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Withdraw [SAPI]",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/withdraw/apply?coin=&address=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"withdraw",
-								"apply"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": ""
-								},
-								{
-									"key": "withdrawOrderId",
-									"value": "",
-									"description": "client id for withdraw",
-									"disabled": true
-								},
-								{
-									"key": "network",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "address",
-									"value": ""
-								},
-								{
-									"key": "addressTag",
-									"value": "",
-									"description": "Secondary address identifier for coins like XRP,XMR etc.",
-									"disabled": true
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "transactionFeeFlag",
-									"value": "",
-									"description": "Boolean value, default: false",
-									"disabled": true
-								},
-								{
-									"key": "name",
-									"value": "",
-									"description": "Description of the address.",
-									"disabled": true
-								},
-								{
-									"key": "walletType",
-									"value": null,
-									"description": "The wallet type for withdraw，0-spot wallet ，1-funding wallet.Default spot wallet",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Deposit History（supporting network） (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/hisrec?coin=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"hisrec"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "BTC"
-								},
-								{
-									"key": "status",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "offset",
-									"value": null,
-									"description": "Default:0",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": null,
-									"description": "Default:1000, Max:1000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Withdraw History (supporting network) (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/withdraw/history?coin=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"withdraw",
-								"history"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "BTC"
-								},
-								{
-									"key": "withdrawOrderId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "status",
-									"value": null,
-									"description": "0:Email Sent,1:Cancelled 2:Awaiting Approval 3:Rejected 4:Processing 5:Failure 6:Completed",
-									"disabled": true
-								},
-								{
-									"key": "offset",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "100",
-									"description": "Default: 1000, Max: 1000",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"description": "Default: 90 days from current timestamp",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"description": "Default: present timestamp",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Deposit Address (supporting network) (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/address?coin=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"address"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "BTC"
-								},
-								{
-									"key": "network",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Account Status(SAPI) (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "X-MBX-APIKEY",
 								"value": "{{binance-api-key}}",
 								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/account/status?timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/algo/futures/newOrderVp?symbol=&side=SELL&quantity=&urgency=LOW&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"sapi",
 								"v1",
-								"account",
-								"status"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Account API Trading Status(SAPI) (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/apiTradingStatus?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"apiTradingStatus"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "DustLog(USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/dribblet?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"dribblet"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Dust Transfer (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/dust?asset=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"dust"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "",
-									"description": "The asset being converted."
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Asset Dividend Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/assetDividend?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"assetDividend"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "20",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Asset Detail(SAPI) (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							},
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/assetDetail?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"assetDetail"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Trade Fee(SAPI) (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/tradeFee?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"tradeFee"
+								"algo",
+								"futures",
+								"newOrderVp"
 							],
 							"query": [
 								{
 									"key": "symbol",
 									"value": "",
+									"description": "Trading symbol eg. BTCUSDT"
+								},
+								{
+									"key": "side",
+									"value": "SELL",
+									"description": "Trading side ( BUY or SELL )"
+								},
+								{
+									"key": "positionSide",
+									"value": "",
+									"description": "Default BOTH for One-way Mode ; LONG or SHORT for Hedge Mode. It must be sent in Hedge Mode.",
+									"disabled": true
+								},
+								{
+									"key": "quantity",
+									"value": "",
+									"description": "Quantity of base asset; The notional (quantity * mark price(base asset)) must be more than the equivalent of 10,000 USDT and less than the equivalent of 1,000,000 USDT."
+								},
+								{
+									"key": "urgency",
+									"value": "LOW",
+									"description": "Represent the relative speed of the current execution; ENUM: LOW, MEDIUM, HIGH."
+								},
+								{
+									"key": "clientAlgoId",
+									"value": "",
+									"description": "A unique id among Algo orders (length should be 32 characters)， If it is not sent, we will give default value.",
+									"disabled": true
+								},
+								{
+									"key": "reduceOnly",
+									"value": "",
+									"description": "\"true\" or \"false\". Default \"false\"; Cannot be sent in Hedge Mode; Cannot be sent when you open a position.",
+									"disabled": true
+								},
+								{
+									"key": "limitPrice",
+									"value": "",
+									"description": "Limit price of the order; If it is not sent, will place order by market price by default.",
 									"disabled": true
 								},
 								{
 									"key": "recvWindow",
-									"value": null,
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Send in a VP new order. Only support on USDⓈ-M Contracts.\n\nWeight(IP): 3000\n\n- Max open orders allowed: 10 orders.\n- Leverage of symbols and position mode will be the same as your futures account settings. You can set up through the trading page or fapi.\n- Receiving \"success\": true does not mean that your order will be executed. Please use the query order endpoints（GET sapi/v1/algo/futures/openOrders or GET sapi/v1/algo/futures/historicalOrders） to check the order status. For example: Your futures balance is insufficient, or open position with reduce only or position side is inconsistent with your own setting. In these cases you will receive \"success\": true, but the order status will be expired after we check it."
 					},
 					"response": []
 				},
 				{
-					"name": "User Universal Transfer",
+					"name": "Cancel Algo Order (TRADE)",
 					"request": {
-						"method": "POST",
+						"method": "DELETE",
 						"header": [
 							{
 								"key": "Content-Type",
@@ -6143,61 +3291,51 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/asset/transfer?type=&asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/algo/futures/order?algoId=14511&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"sapi",
 								"v1",
-								"asset",
-								"transfer"
+								"algo",
+								"futures",
+								"order"
 							],
 							"query": [
 								{
-									"key": "type",
-									"value": ""
+									"key": "algoId",
+									"value": "14511"
 								},
 								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "fromSymbol",
-									"value": null,
-									"description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
-									"disabled": true
-								},
-								{
-									"key": "toSymbol",
-									"value": null,
-									"description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Cancel an active order.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Query User Universal Transfer History",
+					"name": "Query Current Algo Open Orders (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -6208,127 +3346,134 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/asset/transfer?type=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/algo/futures/openOrders?timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"sapi",
 								"v1",
-								"asset",
-								"transfer"
+								"algo",
+								"futures",
+								"openOrders"
 							],
 							"query": [
 								{
-									"key": "type",
-									"value": ""
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Historical Algo Orders (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/algo/futures/historicalOrders?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"algo",
+								"futures",
+								"historicalOrders"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "",
+									"description": "Trading symbol eg. BTCUSDT",
+									"disabled": true
+								},
+								{
+									"key": "side",
+									"value": "",
+									"description": "BUY or SELL",
+									"disabled": true
 								},
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
-									"key": "current",
+									"key": "page",
 									"value": "",
-									"description": "Default 1",
+									"description": "Default is 1",
 									"disabled": true
 								},
 								{
-									"key": "size",
+									"key": "pageSize",
 									"value": "",
-									"description": "Default 10, Max 100",
+									"description": "MIN 1, MAX 100; Default 100",
 									"disabled": true
 								},
 								{
-									"key": "fromSymbol",
-									"value": null,
-									"description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
-									"disabled": true
-								},
-								{
-									"key": "toSymbol",
-									"value": null,
-									"description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Funding Wallet",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/get-funding-asset?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"get-funding-asset"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "needBtcValuation",
-									"value": "",
-									"description": "true or false",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "API Key Permission (USER_DATA)",
+					"name": "Query Sub Orders (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -6339,527 +3484,69 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/account/apiRestrictions?timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/algo/futures/subOrders?timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"sapi",
 								"v1",
-								"account",
-								"apiRestrictions"
+								"algo",
+								"futures",
+								"subOrders"
 							],
 							"query": [
 								{
+									"key": "algoId",
+									"value": "13723",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "",
+									"description": "Default is 1",
+									"disabled": true
+								},
+								{
+									"key": "pageSize",
+									"value": "",
+									"description": "MIN 1, MAX 100; Default 100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get respective sub orders for a specified algoId\n\nWeight(IP): 1"
 					},
 					"response": []
-				}
-			]
+				}],
+			"description": ""
 		},
-		{
-			"name": "Margin",
+			{
+			"name": "Gift Card",
 			"item": [
 				{
-					"name": "isolated",
-					"item": [
-						{
-							"name": "Isolated Margin Account Transfer (MARGIN)",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/transfer?asset=&symbol=&transFrom=&transTo=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"transfer"
-									],
-									"query": [
-										{
-											"key": "asset",
-											"value": ""
-										},
-										{
-											"key": "symbol",
-											"value": "",
-											"description": "isolated symbol"
-										},
-										{
-											"key": "transFrom",
-											"value": "",
-											"description": "\"SPOT\", \"ISOLATED_MARGIN\""
-										},
-										{
-											"key": "transTo",
-											"value": "",
-											"description": "\"SPOT\", \"ISOLATED_MARGIN\""
-										},
-										{
-											"key": "amount",
-											"value": ""
-										},
-										{
-											"key": "recvWindow",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Get Isolated Margin Account Transfer History (USER_DATA)",
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/transfer?symbol=&timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"transfer"
-									],
-									"query": [
-										{
-											"key": "asset",
-											"value": "",
-											"disabled": true
-										},
-										{
-											"key": "symbol",
-											"value": ""
-										},
-										{
-											"key": "transFrom",
-											"value": "",
-											"description": "\"SPOT\", \"ISOLATED_MARGIN\"",
-											"disabled": true
-										},
-										{
-											"key": "transTo",
-											"value": "",
-											"description": "\"SPOT\", \"ISOLATED_MARGIN\"",
-											"disabled": true
-										},
-										{
-											"key": "startTime",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "endTime",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "current",
-											"value": "1",
-											"description": "Currently querying page. Start from 1. Default:1",
-											"disabled": true
-										},
-										{
-											"key": "size",
-											"value": "10",
-											"description": "Default:10 Max:100",
-											"disabled": true
-										},
-										{
-											"key": "recvWindow",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Query Isolated Margin Account Info (USER_DATA)",
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/account?timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"account"
-									],
-									"query": [
-										{
-											"key": "symbols",
-											"value": "",
-											"description": "Max 5 symbols can be sent; separated by ','. e.g. 'BTCUSDT,BNBUSDT,ADAUSDT'",
-											"disabled": true
-										},
-										{
-											"key": "recvWindow",
-											"value": "",
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Query Isolated Margin Symbol (USER_DATA)",
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/pair?symbol=&timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"pair"
-									],
-									"query": [
-										{
-											"key": "symbol",
-											"value": ""
-										},
-										{
-											"key": "recvWindow",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Get All Isolated Margin Symbol (USER_DATA)",
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/allPairs?timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"allPairs"
-									],
-									"query": [
-										{
-											"key": "recvWindow",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Disable Isolated Margin Account (TRADE)",
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=&timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"account"
-									],
-									"query": [
-										{
-											"key": "symbol",
-											"value": ""
-										},
-										{
-											"key": "recvWindow",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Enable Isolated Margin Account (TRADE)",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=&timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"account"
-									],
-									"query": [
-										{
-											"key": "symbol",
-											"value": ""
-										},
-										{
-											"key": "recvWindow",
-											"value": null,
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "Query Enabled Isolated Margin Account Limit (USER_DATA)",
-							"request": {
-								"method": "GET",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/margin/isolated/accountLimit?timestamp={{timestamp}}&signature={{signature}}",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"margin",
-										"isolated",
-										"accountLimit"
-									],
-									"query": [
-										{
-											"key": "recvWindow",
-											"value": "",
-											"disabled": true
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
-									]
-								}
-							},
-							"response": []
-						}
-					],
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"type": "text/javascript",
-								"exec": [
-									""
-								]
-							}
-						}
-					]
-				},
-				{
-					"name": "Margin Account Transfer (MARGIN)",
+					"name": "Create a Binance Code (USER_DATA)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -6870,12 +3557,187 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/transfer?asset=BTC&amount&type&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/giftcard/createCode?token=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"giftcard",
+								"createCode"
+							],
+							"query": [
+								{
+									"key": "token",
+									"value": "",
+									"description": "The coin type contained in the Binance Code"
+								},
+								{
+									"key": "amount",
+									"value": "",
+									"description": "The amount of the coin"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "This API is for creating a Binance Code. To get started with, please make sure:\n\n- You have a Binance account\n- You have passed kyc\n- You have a sufﬁcient balance in your Binance funding wallet\n- You need Enable Withdrawals for the API Key which requests this endpoint.\n\nDaily creation volume: 2 BTC / 24H Daily creation times: 200 Codes / 24H\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Redeem a Binance Code (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/giftcard/redeemCode?code=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"giftcard",
+								"redeemCode"
+							],
+							"query": [
+								{
+									"key": "code",
+									"value": "",
+									"description": "Binance Code"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "This API is for redeeming the Binance Code. Once redeemed, the coins will be deposited in your funding wallet.\n\nPlease note that if you enter the wrong code 5 times within 24 hours, you will no longer be able to redeem any Binance Code that day.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Verify a Binance Code (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/giftcard/verify?referenceNo=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"giftcard",
+								"verify"
+							],
+							"query": [
+								{
+									"key": "referenceNo",
+									"value": "",
+									"description": "reference number"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "This API is for verifying whether the Binance Code is valid or not by entering Binance Code or reference number.\n\nPlease note that if you enter the wrong binance code 5 times within an hour, you will no longer be able to verify any binance code for that hour.\n\nWeight(IP): 1"
+					},
+					"response": []
+				}],
+			"description": "Gift Card Endpoints"
+		},
+			{
+			"name": "Margin",
+			"item": [
+				{
+					"name": "Cross Margin Account Transfer (MARGIN)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/transfer?asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -6892,23 +3754,123 @@
 								},
 								{
 									"key": "amount",
-									"value": null
+									"value": "1.01"
 								},
 								{
 									"key": "type",
-									"value": null,
-									"description": "1: transfer from main account to margin account 2: transfer from margin account to main account"
+									"value": "",
+									"description": "* `1` - transfer from main account to margin account\n* `2` - transfer from margin account to main account"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Execute transfer between spot account and cross margin account.\n\nWeight(IP): 600"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Cross Margin Transfer History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/transfer?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"transfer"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BNB",
+									"disabled": true
+								},
+								{
+									"key": "type",
+									"value": "",
+									"description": "Transfer Type",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "current",
+									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
+									"disabled": true
+								},
+								{
+									"key": "size",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "archived",
+									"value": "",
+									"description": "Default: false. Set to true for archived data from 6 months ago",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- Response in descending order\n- Returns data for last 7 days by default\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -6924,12 +3886,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/loan?asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/loan?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -6942,34 +3904,139 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": ""
+									"value": "BTC"
 								},
 								{
 									"key": "isIsolated",
 									"value": "",
-									"description": "\"TRUE\", \"FALSE\"，default: “FALSE”",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
 									"disabled": true
 								},
 								{
 									"key": "symbol",
-									"value": "",
-									"description": "isolated symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
 									"disabled": true
 								},
 								{
 									"key": "amount",
-									"value": ""
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Apply for a loan.\n\n- If \"isIsolated\" = \"TRUE\", \"symbol\" must be sent\n- \"isIsolated\" = \"FALSE\" for crossed margin loan\n\nWeight(UID): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Loan Record (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/loan?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"loan"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "isolatedSymbol",
+									"value": "",
+									"description": "Isolated symbol",
+									"disabled": true
+								},
+								{
+									"key": "txId",
+									"value": "123456789",
+									"description": "the tranId in  `POST /sapi/v1/margin/loan`",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "current",
+									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
+									"disabled": true
+								},
+								{
+									"key": "size",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "archived",
+									"value": "",
+									"description": "Default: false. Set to true for archived data from 6 months ago",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- `txId` or `startTime` must be sent. `txId` takes precedence.\n- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -6985,12 +4052,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/repay?asset=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/repay?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -7003,34 +4070,139 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": ""
+									"value": "BTC"
 								},
 								{
 									"key": "isIsolated",
 									"value": "",
-									"description": "\"TRUE\", \"FALSE\"，default: “FALSE”",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
 									"disabled": true
 								},
 								{
 									"key": "symbol",
-									"value": "",
-									"description": "isolated symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
 									"disabled": true
 								},
 								{
 									"key": "amount",
-									"value": ""
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Repay loan for margin account.\n\n- If \"isIsolated\" = \"TRUE\", \"symbol\" must be sent\n- \"isIsolated\" = \"FALSE\" for crossed margin repay\n\nWeight(IP): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Repay Record (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/repay?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"repay"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "isolatedSymbol",
+									"value": "",
+									"description": "Isolated symbol",
+									"disabled": true
+								},
+								{
+									"key": "txId",
+									"value": "2970933056",
+									"description": "the tranId in  `POST /sapi/v1/margin/repay`",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "current",
+									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
+									"disabled": true
+								},
+								{
+									"key": "size",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "archived",
+									"value": "",
+									"description": "Default: false. Set to true for archived data from 6 months ago",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- `txId` or `startTime` must be sent. `txId` takes precedence.\n- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -7046,8 +4218,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -7067,7 +4239,8 @@
 									"value": "BTC"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 10"
 					},
 					"response": []
 				},
@@ -7083,12 +4256,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/pair?symbol=BTCUSDT",
+							"raw": "{{url}}/sapi/v1/margin/pair?symbol=BNBUSDT",
 							"host": [
 								"{{url}}"
 							],
@@ -7101,10 +4274,12 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 10"
 					},
 					"response": []
 				},
@@ -7120,8 +4295,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -7135,7 +4310,8 @@
 								"margin",
 								"allAssets"
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -7151,8 +4327,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -7166,7 +4342,8 @@
 								"margin",
 								"allPairs"
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -7182,12 +4359,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/priceIndex?symbol=BTCUSDT",
+							"raw": "{{url}}/sapi/v1/margin/priceIndex?symbol=BNBUSDT",
 							"host": [
 								"{{url}}"
 							],
@@ -7200,10 +4377,85 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Margin Account's Order (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"order"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "isIsolated",
+									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "orderId",
+									"value": "",
+									"description": "Order id",
+									"disabled": true
+								},
+								{
+									"key": "origClientOrderId",
+									"value": "",
+									"description": "Order id from client",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- Either `orderId` or `origClientOrderId` must be sent.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -7219,12 +4471,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order?symbol=&side=&type=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&side=SELL&type=&quantity=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -7237,77 +4489,95 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": ""
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "isIsolated",
 									"value": "",
-									"description": "\"TRUE\", \"FALSE\"，default: “FALSE”",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
 									"disabled": true
 								},
 								{
 									"key": "side",
-									"value": ""
+									"value": "SELL"
 								},
 								{
 									"key": "type",
-									"value": ""
+									"value": "",
+									"description": "Order type"
 								},
 								{
 									"key": "quantity",
-									"value": "",
-									"disabled": true
+									"value": ""
 								},
 								{
 									"key": "quoteOrderQty",
 									"value": "",
+									"description": "Quote quantity",
 									"disabled": true
 								},
 								{
 									"key": "price",
 									"value": "",
+									"description": "Order price",
 									"disabled": true
 								},
 								{
 									"key": "stopPrice",
-									"value": "",
+									"value": "20.01",
+									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
 									"disabled": true
 								},
 								{
 									"key": "newClientOrderId",
 									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
 									"disabled": true
 								},
 								{
 									"key": "icebergQty",
 									"value": "",
+									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
 									"disabled": true
 								},
 								{
 									"key": "newOrderRespType",
 									"value": "",
+									"description": "Set the response JSON.",
 									"disabled": true
 								},
 								{
 									"key": "sideEffectType",
 									"value": "",
+									"description": "Default `NO_SIDE_EFFECT`",
 									"disabled": true
 								},
 								{
 									"key": "timeInForce",
 									"value": "",
+									"description": "Order time in force",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Post a new order for margin account.\n\nWeight(UID): 6"
 					},
 					"response": []
 				},
@@ -7323,12 +4593,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order?symbol=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -7341,326 +4611,52 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": ""
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "isIsolated",
 									"value": "",
-									"description": "\"TRUE\", \"FALSE\"，default: “FALSE”",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
 									"disabled": true
 								},
 								{
 									"key": "orderId",
 									"value": "",
+									"description": "Order id",
 									"disabled": true
 								},
 								{
 									"key": "origClientOrderId",
 									"value": "",
+									"description": "Order id from client",
 									"disabled": true
 								},
 								{
 									"key": "newClientOrderId",
 									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account Cancel all Open Orders on a Symbol",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/openOrders?symbol=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"openOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": ""
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "\"TRUE\", \"FALSE\"，default: “FALSE”",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Get Transfer History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/transfer?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTCUSDT",
-									"disabled": true
-								},
-								{
-									"key": "type",
-									"value": null,
-									"description": "Tranfer Type: ROLL_IN, ROLL_OUT",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Currently querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "10",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Loan Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/loan?asset=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"loan"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "txId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "10",
-									"disabled": true
-								},
-								{
-									"key": "archived",
-									"value": "false",
-									"description": "Default: false. Set to true for archived data from 6 months ago",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Repay Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/repay?asset=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"repay"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "txId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "10",
-									"disabled": true
-								},
-								{
-									"key": "archived",
-									"value": "false",
-									"description": "Default: false. Set to true for archived data from 6 months ago",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
+						},
+						"description": "Cancel an active order for margin account.\n\nEither `orderId` or `origClientOrderId` must be sent.\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -7676,8 +4672,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -7694,50 +4690,64 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": "",
+									"value": "BNB",
 									"disabled": true
 								},
 								{
 									"key": "isolatedSymbol",
 									"value": "",
+									"description": "Isolated symbol",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "current",
 									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
 									"key": "size",
-									"value": "10",
+									"value": "100",
+									"description": "Default:10 Max:100",
 									"disabled": true
 								},
 								{
 									"key": "archived",
-									"value": "false",
+									"value": "",
 									"description": "Default: false. Set to true for archived data from 6 months ago",
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n- `type` in response has 4 enums:\n  - `PERIODIC` interest charged per hour\n  - `ON_BORROW` first interest charged on borrow\n  - `PERIODIC_CONVERTED` interest charged per hour converted into BNB\n  - `ON_BORROW_CONVERTED` first interest charged on borrow converted into BNB\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -7753,12 +4763,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/forceLiquidationRec?startTime=&endTime=&isolatedSymbol=&current=1&size=10&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/forceLiquidationRec?timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -7771,39 +4781,58 @@
 							"query": [
 								{
 									"key": "startTime",
-									"value": ""
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": ""
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
 								},
 								{
 									"key": "isolatedSymbol",
-									"value": ""
+									"value": "",
+									"description": "Isolated symbol",
+									"disabled": true
 								},
 								{
 									"key": "current",
-									"value": "1"
+									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
+									"disabled": true
 								},
 								{
 									"key": "size",
-									"value": "10"
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- Response in descending order\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Query Margin Account Details (USER_DATA)",
+					"name": "Query Cross Margin Account Details (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -7814,8 +4843,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -7831,20 +4860,29 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 10"
 					},
 					"response": []
 				},
 				{
-					"name": "Query Margin Account's Order (USER_DATA)",
+					"name": "Query Margin Account's Open Orders (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -7855,68 +4893,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order?symbol=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": ""
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's Open Order (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -7933,29 +4911,101 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
 									"disabled": true
 								},
 								{
 									"key": "isIsolated",
 									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- If the `symbol` is not sent, orders for all symbols will be returned in an array.\n- When all symbols are returned, the number of requests counted against the rate limiter is equal to the number of symbols currently trading on the exchange\n- If isIsolated =\"TRUE\", symbol must be sent.\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
 				{
-					"name": "Query Margin Account's All Order (USER_DATA)",
+					"name": "Margin Account Cancel all Open Orders on a Symbol (TRADE)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/openOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"openOrders"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "isIsolated",
+									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- Cancels all active orders on a symbol for margin account.\n- This includes OCO orders.\n\nWeight(IP): 1\n"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Margin Account's All Orders (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -7966,12 +5016,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/allOrders?symbol=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/allOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -7984,44 +5034,489 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": ""
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "isIsolated",
 									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
 									"disabled": true
 								},
 								{
 									"key": "orderId",
 									"value": "",
+									"description": "Order id",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
-									"description": "Default 500; max 1000.",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- If `orderId` is set, it will get orders >= that orderId. Otherwise most recent orders are returned.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 200\n\nRequest Limit: 60 times/min per IP"
+					},
+					"response": []
+				},
+				{
+					"name": "Margin Account New OCO (TRADE)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/order/oco?symbol=BNBUSDT&side=SELL&quantity=&price=&stopPrice=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"order",
+								"oco"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "isIsolated",
+									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "listClientOrderId",
+									"value": "",
+									"description": "A unique Id for the entire orderList",
+									"disabled": true
+								},
+								{
+									"key": "side",
+									"value": "SELL"
+								},
+								{
+									"key": "quantity",
+									"value": ""
+								},
+								{
+									"key": "limitClientOrderId",
+									"value": "",
+									"description": "A unique Id for the limit order",
+									"disabled": true
+								},
+								{
+									"key": "price",
+									"value": "",
+									"description": "Order price"
+								},
+								{
+									"key": "limitIcebergQty",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "stopClientOrderId",
+									"value": "",
+									"description": "A unique Id for the stop loss/stop loss limit leg",
+									"disabled": true
+								},
+								{
+									"key": "stopPrice",
+									"value": ""
+								},
+								{
+									"key": "stopLimitPrice",
+									"value": "",
+									"description": "If provided, stopLimitTimeInForce is required.",
+									"disabled": true
+								},
+								{
+									"key": "stopIcebergQty",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "stopLimitTimeInForce",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "newOrderRespType",
+									"value": "",
+									"description": "Set the response JSON.",
+									"disabled": true
+								},
+								{
+									"key": "sideEffectType",
+									"value": "",
+									"description": "Default `NO_SIDE_EFFECT`",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Send in a new OCO for a margin account\n\n- Price Restrictions:\n  - SELL: Limit Price > Last Price > Stop Price\n  - BUY: Limit Price < Last Price < Stop Price\n- Quantity Restrictions:\n  - Both legs must have the same quantity\n  - ICEBERG quantities however do not have to be the same.\n- Order Rate Limit\n  - OCO counts as 2 orders against the order rate limit.\n\nWeight(UID): 6"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Margin Account's OCO (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/orderList?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"orderList"
+							],
+							"query": [
+								{
+									"key": "isIsolated",
+									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "symbol",
+									"value": "",
+									"description": "Mandatory for isolated margin, not supported for cross margin",
+									"disabled": true
+								},
+								{
+									"key": "orderListId",
+									"value": "",
+									"description": "Order list id",
+									"disabled": true
+								},
+								{
+									"key": "origClientOrderId",
+									"value": "",
+									"description": "Order id from client",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Retrieves a specific OCO based on provided optional parameters\n\n- Either `orderListId` or `origClientOrderId` must be provided\n\nWeight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Margin Account Cancel OCO (TRADE)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/orderList?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"orderList"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "isIsolated",
+									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "orderListId",
+									"value": "",
+									"description": "Order list id",
+									"disabled": true
+								},
+								{
+									"key": "listClientOrderId",
+									"value": "",
+									"description": "A unique Id for the entire orderList",
+									"disabled": true
+								},
+								{
+									"key": "newClientOrderId",
+									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Cancel an entire Order List for a margin account\n\n- Canceling an individual leg will cancel the entire OCO\n- Either `orderListId` or `listClientOrderId` must be provided\n\nWeight(UID): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Margin Account's all OCO (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/allOrderList?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"allOrderList"
+							],
+							"query": [
+								{
+									"key": "isIsolated",
+									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "symbol",
+									"value": "",
+									"description": "Mandatory for isolated margin, not supported for cross margin",
+									"disabled": true
+								},
+								{
+									"key": "fromId",
+									"value": "",
+									"description": "If supplied, neither `startTime` or `endTime` can be provided",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"description": "Default Value: 500; Max Value: 1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Retrieves all OCO for a specific margin account based on provided optional parameters\n\nWeight(IP): 200"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Margin Account's Open OCO (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/openOrderList?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"openOrderList"
+							],
+							"query": [
+								{
+									"key": "isIsolated",
+									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+									"disabled": true
+								},
+								{
+									"key": "symbol",
+									"value": "",
+									"description": "Mandatory for isolated margin, not supported for cross margin",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
 					},
 					"response": []
 				},
@@ -8037,12 +5532,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/myTrades?symbol=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/myTrades?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -8055,44 +5550,58 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": ""
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "isIsolated",
 									"value": "",
+									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "fromId",
 									"value": "",
-									"description": "Default 500; max 1000.",
+									"description": "Trade id to fetch from. Default gets most recent trades.",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- If `fromId` is set, it will get orders >= that `fromId`. Otherwise most recent trades are returned.\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -8108,12 +5617,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/maxBorrowable?asset=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/maxBorrowable?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -8126,23 +5635,33 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": ""
+									"value": "BTC"
 								},
 								{
 									"key": "isolatedSymbol",
 									"value": "",
+									"description": "Isolated symbol",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- If `isolatedSymbol` is not sent, crossed margin data will be sent.\n- `borrowLimit` is also available from https://www.binance.com/en/margin-fee\n\nWeight(IP): 50"
 					},
 					"response": []
 				},
@@ -8158,12 +5677,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/maxTransferable?asset=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/maxTransferable?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -8176,23 +5695,527 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": ""
+									"value": "BTC"
 								},
 								{
 									"key": "isolatedSymbol",
 									"value": "",
+									"description": "Isolated symbol",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- If `isolatedSymbol` is not sent, crossed margin data will be sent.\n\nWeight(IP): 50"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Isolated Margin Transfer History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/transfer?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"transfer"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BNB",
+									"disabled": true
+								},
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "transFrom",
+									"value": "SPOT",
+									"disabled": true
+								},
+								{
+									"key": "transTo",
+									"value": "ISOLATED_MARGIN",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "current",
+									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
+									"disabled": true
+								},
+								{
+									"key": "size",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Isolated Margin Account Transfer (MARGIN)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/transfer?asset=BTC&symbol=BNBUSDT&transFrom=SPOT&transTo=ISOLATED_MARGIN&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"transfer"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "transFrom",
+									"value": "SPOT"
+								},
+								{
+									"key": "transTo",
+									"value": "ISOLATED_MARGIN"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(UID): 600"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Isolated Margin Account Info (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/account?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"account"
+							],
+							"query": [
+								{
+									"key": "symbols",
+									"value": "BTCUSDT,BNBUSDT,ADAUSDT",
+									"description": "Max 5 symbols can be sent; separated by ','",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- If \"symbols\" is not sent, all isolated assets will be returned.\n- If \"symbols\" is sent, only the isolated assets of the sent symbols will be returned.\n\nWeight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Disable Isolated Margin Account (TRADE)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"account"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Disable isolated margin account for a specific symbol. Each trading pair can only be deactivated once every 24 hours .\n\nWeight(UID): 300"
+					},
+					"response": []
+				},
+				{
+					"name": "Enable Isolated Margin Account (TRADE)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"account"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Enable isolated margin account for a specific symbol.\n\nWeight(UID): 300"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Enabled Isolated Margin Account Limit (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/accountLimit?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"accountLimit"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Query enabled isolated margin account limit.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Isolated Margin Symbol (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/pair?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"pair"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Isolated Margin Symbol (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/isolated/allPairs?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"isolated",
+								"allPairs"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
 					},
 					"response": []
 				},
@@ -8208,8 +6231,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -8225,26 +6248,35 @@
 							"query": [
 								{
 									"key": "spotBNBBurn",
-									"value": "",
-									"description": "\"true\" or \"false\"",
+									"value": "true",
+									"description": "Determines whether to use BNB to pay for trading fees on SPOT",
 									"disabled": true
 								},
 								{
 									"key": "interestBNBBurn",
-									"value": "",
-									"description": "\"true\" or \"false\"",
+									"value": "false",
+									"description": "Determines whether to use BNB to pay for margin loan's interest",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- \"spotBNBBurn\" and \"interestBNBBurn\" should be sent at least one.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -8260,8 +6292,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -8276,15 +6308,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -8300,12 +6341,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/interestRateHistory?asset=&recvWindow=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/interestRateHistory?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -8318,41 +6359,45 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": ""
+									"value": "BTC"
 								},
 								{
 									"key": "vipLevel",
 									"value": "",
-									"description": "Default: user's vip level",
+									"description": "Defaults to user's vip level",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
 									"value": "",
-									"description": "Default: 7 days ago",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
-									"description": "Default: present. Maximum range: 3 months.",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "recvWindow",
-									"value": "",
-									"description": "No more than 60000"
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "The max interval between startTime and endTime is 30 days.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -8368,8 +6413,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -8387,24 +6432,34 @@
 								{
 									"key": "vipLevel",
 									"value": "",
-									"description": "User's current specific margin data will be returned if vipLevel is omitted",
+									"description": "Defaults to user's vip level",
 									"disabled": true
 								},
 								{
 									"key": "coin",
-									"value": "",
+									"value": "BNB",
+									"description": "Coin name",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get cross margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee\n\nWeight(IP): 1 when coin is specified; 5 when the coin parameter is omitted"
 					},
 					"response": []
 				},
@@ -8420,8 +6475,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -8439,24 +6494,34 @@
 								{
 									"key": "vipLevel",
 									"value": "",
-									"description": "User's current specific margin data will be returned if vipLevel is omitted",
+									"description": "Defaults to user's vip level",
 									"disabled": true
 								},
 								{
 									"key": "symbol",
-									"value": "",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get isolated margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee\n\nWeight(IP): 1 when a single is specified; 10 when the symbol parameter is omitted"
 					},
 					"response": []
 				},
@@ -8472,12 +6537,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolatedMarginTier?symbol=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/margin/isolatedMarginTier?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -8490,412 +6555,40 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": ""
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "tier",
-									"value": "",
+									"value": "1",
 									"description": "All margin tier data will be returned if tier is omitted",
 									"disabled": true
 								},
 								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account New OCO (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order/oco?symbol=BTCUSDT&side=&quantity=&price&stopPrice&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"order",
-								"oco"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BTCUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": null,
-									"description": "For isolated margin or not, \"TRUE\", \"FALSE\"，default \"FALSE\"",
-									"disabled": true
-								},
-								{
-									"key": "listClientOrderId",
-									"value": "",
-									"description": "A unique Id for the entire orderList",
-									"disabled": true
-								},
-								{
-									"key": "side",
-									"value": ""
-								},
-								{
-									"key": "quantity",
-									"value": ""
-								},
-								{
-									"key": "limitClientOrderId",
-									"value": "",
-									"description": "A unique Id for the limit order",
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": null
-								},
-								{
-									"key": "limitIcebergQty",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "stopClientOrderId",
-									"value": "",
-									"description": "A unique Id for the stop loss/stop loss limit leg",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": null
-								},
-								{
-									"key": "stopLimitPrice",
-									"value": "",
-									"description": "If provided, stopLimitTimeInForce is required.",
-									"disabled": true
-								},
-								{
-									"key": "stopIcebergQty",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "stopLimitTimeInForce",
-									"value": "",
-									"description": "Valid values are GTC/FOK/IOC",
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": "",
-									"description": "Set the response JSON.",
-									"disabled": true
-								},
-								{
-									"key": "sideEffectType",
-									"value": null,
-									"description": "NO_SIDE_EFFECT, MARGIN_BUY, AUTO_REPAY; default NO_SIDE_EFFECT.",
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get isolated margin tier data collection with any tier as https://www.binance.com/en/margin-data\n\nWeight(IP): 1"
 					},
 					"response": []
-				},
-				{
-					"name": "Margin Account Cancel OCO (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/orderList?symbol=BTCUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"orderList"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BTCUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": null,
-									"description": "For isolated margin or not, \"TRUE\", \"FALSE\"，default \"FALSE\"",
-									"disabled": true
-								},
-								{
-									"key": "orderListId",
-									"value": "",
-									"description": "Either orderListId or listClientOrderId must be provided",
-									"disabled": true
-								},
-								{
-									"key": "listClientOrderId",
-									"value": "",
-									"description": "Either orderListId or listClientOrderId must be provided",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/orderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"orderList"
-							],
-							"query": [
-								{
-									"key": "isIsolated",
-									"value": null,
-									"description": "For isolated margin or not, \"TRUE\", \"FALSE\"，default \"FALSE\"",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Mandatory for isolated margin, not supported for cross margin",
-									"disabled": true
-								},
-								{
-									"key": "orderListId",
-									"value": "",
-									"description": "Either orderListId or listClientOrderId must be provided",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"description": "Either orderListId or listClientOrderId must be provided",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's all OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/allOrderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"allOrderList"
-							],
-							"query": [
-								{
-									"key": "isIsolated",
-									"value": null,
-									"description": "For isolated margin or not, \"TRUE\", \"FALSE\"，default \"FALSE\"",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Mandatory for isolated margin, not supported for cross margin",
-									"disabled": true
-								},
-								{
-									"key": "fromId",
-									"value": "",
-									"description": "If supplied, neither startTime or endTime can be provided",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": null,
-									"description": "Default Value: 500; Max Value: 1000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's Open OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/openOrderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"openOrderList"
-							],
-							"query": [
-								{
-									"key": "isIsolated",
-									"value": null,
-									"description": "For isolated margin or not, \"TRUE\", \"FALSE\"，default \"FALSE\"",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Mandatory for isolated margin, not supported for cross margin",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				}
-			]
+				}],
+			"description": "Margin Account/Trade"
 		},
-		{
+			{
 			"name": "Market",
 			"item": [
 				{
@@ -8905,8 +6598,8 @@
 						"header": [
 							{
 								"key": "Content-Type",
-								"value": "application/json",
-								"type": "text"
+								"type": "text",
+								"value": "application/json"
 							}
 						],
 						"url": {
@@ -8920,7 +6613,7 @@
 								"ping"
 							]
 						},
-						"description": "Test connectivity to the Rest API."
+						"description": "Test connectivity to the Rest API.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -8946,7 +6639,7 @@
 								"time"
 							]
 						},
-						"description": "Test connectivity to the Rest API and get the current server time."
+						"description": "Test connectivity to the Rest API and get the current server time.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -8974,17 +6667,18 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BNBBTC",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
 									"disabled": true
 								},
 								{
 									"key": "symbols",
 									"value": "[\"BTCUSDT\",\"BNBBTC\"]",
-									"description": "add double quote for each symbol in list",
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Current exchange trading rules and symbol information\n\n- If any symbol provided in either symbol or symbols do not exist, the endpoint will throw an error.\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -9000,7 +6694,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/depth?symbol=BTCUSDT",
+							"raw": "{{url}}/api/v3/depth?symbol=BNBUSDT",
 							"host": [
 								"{{url}}"
 							],
@@ -9012,16 +6706,18 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "limit",
 									"value": "100",
-									"description": "Default 100; max 1000. Valid limits:[5, 10, 20, 50, 100, 500, 1000, 5000]",
+									"description": "If limit > 5000, then the response will truncate to 5000",
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "| Limit               | Weight(IP)  |\n|---------------------|-------------|\n| 1-100               | 1           |\n| 101-500             | 5           |\n| 501-1000            | 10          |\n| 1001-5000           | 50          |"
 					},
 					"response": []
 				},
@@ -9037,7 +6733,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/trades?symbol=BTCUSDT",
+							"raw": "{{url}}/api/v3/trades?symbol=BNBUSDT",
 							"host": [
 								"{{url}}"
 							],
@@ -9049,7 +6745,8 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "limit",
@@ -9058,7 +6755,8 @@
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Get recent trades.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -9074,12 +6772,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/historicalTrades?symbol=BTCUSDT",
+							"raw": "{{url}}/api/v3/historicalTrades?symbol=BNBUSDT",
 							"host": [
 								"{{url}}"
 							],
@@ -9091,7 +6789,8 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "limit",
@@ -9101,11 +6800,13 @@
 								},
 								{
 									"key": "fromId",
-									"value": null,
+									"value": "",
+									"description": "Trade id to fetch from. Default gets most recent trades.",
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Get older market trades.\n\nWeight(IP): 5"
 					},
 					"response": []
 				},
@@ -9121,7 +6822,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/aggTrades?symbol=BTCUSDT",
+							"raw": "{{url}}/api/v3/aggTrades?symbol=BNBUSDT",
 							"host": [
 								"{{url}}"
 							],
@@ -9133,21 +6834,25 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "fromId",
 									"value": "",
+									"description": "Trade id to fetch from. Default gets most recent trades.",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
@@ -9157,7 +6862,8 @@
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Get compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.\n- If `startTime` and `endTime` are sent, time between startTime and endTime must be less than 1 hour.\n- If `fromId`, `startTime`, and `endTime` are not sent, the most recent aggregate trades will be returned.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -9173,7 +6879,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/klines?symbol=BTCUSDT&interval=1m",
+							"raw": "{{url}}/api/v3/klines?symbol=BNBUSDT&interval=",
 							"host": [
 								"{{url}}"
 							],
@@ -9185,20 +6891,24 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "interval",
-									"value": "1m"
+									"value": "",
+									"description": "kline intervals"
 								},
 								{
 									"key": "startTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
 									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
@@ -9208,7 +6918,8 @@
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Kline/candlestick bars for a symbol.\nKlines are uniquely identified by their open time.\n\n- If `startTime` and `endTime` are not sent, the most recent klines are returned.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -9224,7 +6935,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/avgPrice?symbol=BTCUSDT",
+							"raw": "{{url}}/api/v3/avgPrice?symbol=BNBUSDT",
 							"host": [
 								"{{url}}"
 							],
@@ -9236,10 +6947,12 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								}
 							]
-						}
+						},
+						"description": "Current average price for a symbol.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -9268,11 +6981,13 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "24 hour rolling window price change statistics. Careful when accessing this with no symbol.\n\n- If the symbol is not sent, tickers for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `40` when the symbol parameter is omitted;"
 					},
 					"response": []
 				},
@@ -9301,11 +7016,13 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Latest price for a symbol or symbols.\n\n- If the symbol is not sent, prices for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `2` when the symbol parameter is omitted;"
 					},
 					"response": []
 				},
@@ -9334,17 +7051,19 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
 									"disabled": true
 								}
 							]
-						}
+						},
+						"description": "Best price/qty on the order book for a symbol or symbols.\n\n- If the symbol is not sent, bookTickers for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `2` when the symbol parameter is omitted;"
 					},
 					"response": []
-				}
-			]
+				}],
+			"description": "Market Data"
 		},
-		{
+			{
 			"name": "Mining",
 			"item": [
 				{
@@ -9359,12 +7078,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/mining/pub/algoList?timestamp={{timestamp}}",
+							"raw": "{{url}}/sapi/v1/mining/pub/algoList?timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -9377,11 +7096,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -9397,12 +7129,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/mining/pub/coinList?timestamp={{timestamp}}",
+							"raw": "{{url}}/sapi/v1/mining/pub/coinList?timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -9415,11 +7147,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -9435,8 +7180,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9460,23 +7205,32 @@
 								{
 									"key": "userName",
 									"value": "",
-									"description": "Mining account"
+									"description": "Mining Account"
 								},
 								{
 									"key": "workerName",
 									"value": "",
-									"description": "Miner’s name（required）"
+									"description": "Miner’s name"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -9492,8 +7246,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9517,42 +7271,51 @@
 								{
 									"key": "userName",
 									"value": "",
-									"description": "Mining account"
+									"description": "Mining Account"
 								},
 								{
 									"key": "pageIndex",
 									"value": "",
-									"description": "Page number，default is first page，start form 1",
+									"description": "Page number, default is first page, start form 1",
 									"disabled": true
 								},
 								{
 									"key": "sort",
 									"value": "",
-									"description": "sort sequence（default=0）0 positive sequence，1 negative sequence",
+									"description": "sort sequence（default=0）0 positive sequence, 1 negative sequence",
 									"disabled": true
 								},
 								{
 									"key": "sortColumn",
 									"value": "",
-									"description": "sort sequence（default=0）0 positive sequence，1 negative sequence",
+									"description": "Sort by( default 1): 1: miner name, 2: real-time computing power, 3: daily average computing power, 4: real-time rejection rate, 5: last submission time",
 									"disabled": true
 								},
 								{
 									"key": "workerStatus",
 									"value": "",
-									"description": "miners status（default=0）0 all，1 valid，2 invalid，3failure",
+									"description": "miners status（default=0）0 all, 1 valid, 2 invalid, 3 failure",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -9568,8 +7331,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9593,43 +7356,57 @@
 								{
 									"key": "userName",
 									"value": "",
-									"description": "Mining account"
+									"description": "Mining Account"
 								},
 								{
 									"key": "coin",
-									"value": "",
+									"value": "BNB",
+									"description": "Coin name",
 									"disabled": true
 								},
 								{
 									"key": "startDate",
 									"value": "",
+									"description": "Search date, millisecond timestamp, while empty query all",
 									"disabled": true
 								},
 								{
 									"key": "endDate",
 									"value": "",
+									"description": "Search date, millisecond timestamp, while empty query all",
 									"disabled": true
 								},
 								{
 									"key": "pageIndex",
 									"value": "",
+									"description": "Page number, default is first page, start form 1",
 									"disabled": true
 								},
 								{
 									"key": "pageSize",
-									"value": null,
+									"value": "",
+									"description": "Number of pages, minimum 10, maximum 200",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -9645,8 +7422,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9670,43 +7447,57 @@
 								{
 									"key": "userName",
 									"value": "",
-									"description": "Mining account"
+									"description": "Mining Account"
 								},
 								{
 									"key": "coin",
-									"value": "",
+									"value": "BNB",
+									"description": "Coin name",
 									"disabled": true
 								},
 								{
 									"key": "startDate",
 									"value": "",
+									"description": "Search date, millisecond timestamp, while empty query all",
 									"disabled": true
 								},
 								{
 									"key": "endDate",
 									"value": "",
+									"description": "Search date, millisecond timestamp, while empty query all",
 									"disabled": true
 								},
 								{
 									"key": "pageIndex",
 									"value": "",
+									"description": "Page number, default is first page, start form 1",
 									"disabled": true
 								},
 								{
 									"key": "pageSize",
 									"value": "",
+									"description": "Number of pages, minimum 10, maximum 200",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -9722,8 +7513,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9744,28 +7535,39 @@
 								{
 									"key": "pageIndex",
 									"value": "",
+									"description": "Page number, default is first page, start form 1",
 									"disabled": true
 								},
 								{
 									"key": "pageSize",
 									"value": "",
+									"description": "Number of pages, minimum 10, maximum 200",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
 				{
-					"name": "Hashrate Resale Details (USER_DATA)",
+					"name": "Hashrate Resale Detail (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -9776,8 +7578,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9796,32 +7598,45 @@
 							"query": [
 								{
 									"key": "configId",
-									"value": ""
+									"value": "",
+									"description": "Mining ID"
 								},
 								{
 									"key": "userName",
-									"value": ""
+									"value": "",
+									"description": "Mining Account"
 								},
 								{
 									"key": "pageIndex",
 									"value": "",
+									"description": "Page number, default is first page, start form 1",
 									"disabled": true
 								},
 								{
 									"key": "pageSize",
 									"value": "",
+									"description": "Number of pages, minimum 10, maximum 200",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -9837,12 +7652,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/mining/hash-transfer/config?userName=&algo=&startDate=&endDate=&toPoolUser=&hashRate=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/mining/hash-transfer/config?userName=&algo=&toPoolUser=&hashRate=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -9856,43 +7671,60 @@
 							"query": [
 								{
 									"key": "userName",
-									"value": ""
+									"value": "",
+									"description": "Mining Account"
 								},
 								{
 									"key": "algo",
-									"value": ""
+									"value": "",
+									"description": "Algorithm(sha256)"
 								},
 								{
 									"key": "startDate",
-									"value": ""
+									"value": "",
+									"description": "Search date, millisecond timestamp, while empty query all",
+									"disabled": true
 								},
 								{
 									"key": "endDate",
-									"value": ""
+									"value": "",
+									"description": "Search date, millisecond timestamp, while empty query all",
+									"disabled": true
 								},
 								{
 									"key": "toPoolUser",
-									"value": ""
+									"value": "",
+									"description": "Mining Account"
 								},
 								{
 									"key": "hashRate",
-									"value": ""
+									"value": "",
+									"description": "Resale hashrate h/s must be transferred (BTC is greater than 500000000000 ETH is greater than 500000)"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
 				{
-					"name": "Cancel Hashrate Resale configuration",
+					"name": "Cancel hashrate resale configuration (USER_DATA)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -9903,8 +7735,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9923,22 +7755,33 @@
 							"query": [
 								{
 									"key": "configId",
-									"value": ""
+									"value": "",
+									"description": "Mining ID"
 								},
 								{
 									"key": "userName",
-									"value": ""
+									"value": "",
+									"description": "Mining Account"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -9954,8 +7797,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -9980,18 +7823,27 @@
 								{
 									"key": "userName",
 									"value": "",
-									"description": "Mining account"
+									"description": "Mining Account"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -10007,8 +7859,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -10033,18 +7885,27 @@
 								{
 									"key": "userName",
 									"value": "",
-									"description": "Mining account"
+									"description": "Mining Account"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
 				},
@@ -10060,8 +7921,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -10085,43 +7946,496 @@
 								{
 									"key": "startDate",
 									"value": "",
-									"description": "Millisecond timestamp",
+									"description": "Search date, millisecond timestamp, while empty query all",
 									"disabled": true
 								},
 								{
 									"key": "endDate",
 									"value": "",
-									"description": "Millisecond timestamp",
+									"description": "Search date, millisecond timestamp, while empty query all",
 									"disabled": true
 								},
 								{
 									"key": "pageIndex",
 									"value": "",
-									"description": "Default 1",
+									"description": "Page number, default is first page, start form 1",
 									"disabled": true
 								},
 								{
 									"key": "pageSize",
 									"value": "",
-									"description": "Min 10,Max 200",
+									"description": "Number of pages, minimum 10, maximum 200",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 5"
 					},
 					"response": []
-				}
-			]
+				}],
+			"description": "Mining Endpoints"
 		},
-		{
+			{
+			"name": "NFT",
+			"item": [
+				{
+					"name": "Get NFT Transaction History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/nft/history/transactions?orderType=1&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"nft",
+								"history",
+								"transactions"
+							],
+							"query": [
+								{
+									"key": "orderType",
+									"value": "1",
+									"description": "0: purchase order, 1: sell order, 2: royalty income, 3: primary market order, 4: mint fee"
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "50",
+									"description": "Default 50, Max 50",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Get NFT Deposit History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/nft/history/deposit?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"nft",
+								"history",
+								"deposit"
+							],
+							"query": [
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "50",
+									"description": "Default 50, Max 50",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Get NFT Withdraw History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/nft/history/withdraw?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"nft",
+								"history",
+								"withdraw"
+							],
+							"query": [
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "50",
+									"description": "Default 50, Max 50",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Get NFT Asset (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/nft/user/getAsset?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"nft",
+								"user",
+								"getAsset"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "50",
+									"description": "Default 50, Max 50",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(UID): 3000"
+					},
+					"response": []
+				}],
+			"description": "NFT Endpoints"
+		},
+			{
+			"name": "Pay",
+			"item": [
+				{
+					"name": "Get Pay Trade History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/pay/transactions?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"pay",
+								"transactions"
+							],
+							"query": [
+								{
+									"key": "startTimestamp",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTimestamp",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "100",
+									"description": "default 100, max 100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- If startTimestamp and endTimestamp are not sent, the recent 90 days' data will be returned.\n- The max interval between startTimestamp and endTimestamp is 90 days.\n- Support for querying orders within the last 18 months.\n\nWeight(UID): 3000"
+					},
+					"response": []
+				}],
+			"description": "Pay Endpoints"
+		},
+			{
+			"name": "Rebate",
+			"item": [
+				{
+					"name": "Get Spot Rebate History Records (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/rebate/taxQuery?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"rebate",
+								"taxQuery"
+							],
+							"query": [
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "default 1",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n- The earliest startTime is supported on June 10, 2020\n\nWeight(UID): 3000"
+					},
+					"response": []
+				}],
+			"description": "Rebate Endpoints"
+		},
+			{
 			"name": "Savings",
 			"item": [
 				{
@@ -10156,35 +8470,47 @@
 							"query": [
 								{
 									"key": "status",
-									"value": "ALL",
-									"description": "\"ALL\", \"SUBSCRIBABLE\", \"UNSUBSCRIBABLE\"; default: 'ALL'",
+									"value": "",
+									"description": "Default `ALL`",
 									"disabled": true
 								},
 								{
 									"key": "featured",
-									"value": "ALL",
+									"value": "",
+									"description": "Default `ALL`",
 									"disabled": true
 								},
 								{
 									"key": "current",
-									"value": "",
+									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
 									"key": "size",
-									"value": "",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -10200,12 +8526,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/userLeftQuota?productId=USDT001&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/daily/userLeftQuota?productId=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10219,18 +8545,27 @@
 							"query": [
 								{
 									"key": "productId",
-									"value": "USDT001"
+									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -10246,12 +8581,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/purchase?productId=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/daily/purchase?productId=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10269,23 +8604,32 @@
 								},
 								{
 									"key": "amount",
-									"value": ""
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Get Left Daily Redemption Quota of Flexible Product",
+					"name": "Get Left Daily Redemption Quota of Flexible Product (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -10296,12 +8640,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/userRedemptionQuota?productId=USDT001&type=FAST&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/daily/userRedemptionQuota?productId=&type=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10315,22 +8659,31 @@
 							"query": [
 								{
 									"key": "productId",
-									"value": "USDT001"
+									"value": ""
 								},
 								{
 									"key": "type",
-									"value": "FAST"
+									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -10346,12 +8699,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/redeem?productId=USDT001&amount&type&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/daily/redeem?productId=&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10365,26 +8718,35 @@
 							"query": [
 								{
 									"key": "productId",
-									"value": "USDT001"
+									"value": ""
 								},
 								{
 									"key": "amount",
-									"value": null
+									"value": "1.01"
 								},
 								{
 									"key": "type",
-									"value": null
+									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -10400,12 +8762,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/token/position?asset=USDT&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/daily/token/position?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10420,23 +8782,32 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": "USDT"
+									"value": "BTC"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Get Fixed and Customized Fixed Project List(USER_DATA)",
+					"name": "Get Fixed and Activity Project List (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -10447,12 +8818,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/project/list?type=ACTIVITY&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/project/list?type=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10466,59 +8837,67 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": "USDT",
+									"value": "BNB",
 									"disabled": true
 								},
 								{
 									"key": "type",
-									"value": "ACTIVITY",
-									"description": "\"ACTIVITY\", \"CUSTOMIZED_FIXED\""
+									"value": ""
 								},
 								{
 									"key": "status",
-									"value": "ALL",
-									"description": "ALL\", \"SUBSCRIBABLE\", \"UNSUBSCRIBABLE\"; default \"ALL\"",
+									"value": "",
+									"description": "Default `ALL`",
 									"disabled": true
 								},
 								{
 									"key": "isSortAsc",
-									"value": "true",
+									"value": "",
 									"description": "default \"true\"",
 									"disabled": true
 								},
 								{
 									"key": "sortBy",
-									"value": "START_TIME",
-									"description": "\"START_TIME\", \"LOT_SIZE\", \"INTEREST_RATE\", \"DURATION\"; default \"START_TIME",
+									"value": "",
+									"description": "Default `START_TIME`",
 									"disabled": true
 								},
 								{
 									"key": "current",
 									"value": "1",
-									"description": "Currently querying page. Start from 1. Default:1",
+									"description": "Current querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
 									"key": "size",
-									"value": "10",
-									"description": "Default:10, Max:100",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Purchase Customized Fixed Project (USER_DATA)",
+					"name": "Purchase Fixed/Activity Project (USER_DATA)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -10529,8 +8908,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -10555,20 +8934,29 @@
 									"value": ""
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Get Customized Fixed Project Position (USER_DATA)",
+					"name": "Get Fixed/Activity Project Position (USER_DATA)",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -10579,12 +8967,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/project/position/list?asset=USDT&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/project/position/list?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10599,7 +8987,7 @@
 							"query": [
 								{
 									"key": "asset",
-									"value": "USDT"
+									"value": "BTC"
 								},
 								{
 									"key": "projectId",
@@ -10609,19 +8997,28 @@
 								{
 									"key": "status",
 									"value": "",
-									"description": "\"HOLDING\", \"REDEEMED\"",
+									"description": "Default `ALL`",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -10637,8 +9034,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -10655,15 +9052,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 1"
 					},
 					"response": []
 				},
@@ -10679,12 +9085,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/union/purchaseRecord?lendingType=DAILY&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/union/purchaseRecord?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10698,43 +9104,57 @@
 							"query": [
 								{
 									"key": "lendingType",
-									"value": "DAILY"
+									"value": "",
+									"description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
 								},
 								{
 									"key": "asset",
-									"value": null,
+									"value": "BNB",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "current",
 									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
 									"key": "size",
-									"value": "10",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeigh(IP): 1"
 					},
 					"response": []
 				},
@@ -10750,12 +9170,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/union/redemptionRecord?lendingType=DAILY&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/union/redemptionRecord?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10769,43 +9189,57 @@
 							"query": [
 								{
 									"key": "lendingType",
-									"value": "DAILY"
+									"value": "",
+									"description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
 								},
 								{
 									"key": "asset",
-									"value": null,
+									"value": "BNB",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "current",
 									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
 									"key": "size",
-									"value": "10",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -10821,12 +9255,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/sapi/v1/lending/union/interestHistory?lendingType=DAILY&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/sapi/v1/lending/union/interestHistory?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10840,48 +9274,62 @@
 							"query": [
 								{
 									"key": "lendingType",
-									"value": "DAILY"
+									"value": "",
+									"description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
 								},
 								{
 									"key": "asset",
-									"value": null,
+									"value": "BNB",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "current",
 									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
 									"disabled": true
 								},
 								{
 									"key": "size",
-									"value": "10",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
 				{
-					"name": "Change Fixed/Activity Position to Daily Position(USER_DATA)",
+					"name": "Change Fixed/Activity Position to Daily Position (USER_DATA)",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -10892,8 +9340,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -10922,42 +9370,2418 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "- PositionId is mandatory parameter for fixed position.\n\nWeight(IP): 1"
 					},
 					"response": []
-				}
-			],
-			"description": "Previously it's lending products.",
-			"event": [
+				}],
+			"description": "Savings Endpoints"
+		},
+			{
+			"name": "Sub-Account",
+			"item": [
 				{
-					"listen": "prerequest",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
+					"name": "Create a Virtual Sub-account (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/virtualSubAccount?subAccountString=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"virtualSubAccount"
+							],
+							"query": [
+								{
+									"key": "subAccountString",
+									"value": "",
+									"description": "Please input a string. We will create a virtual email using that string for you to register"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- This request will generate a virtual sub account under your master account.\n- You need to enable \"trade\" option for the api key which requests this endpoint.\n\nWeight(IP): 1"
+					},
+					"response": []
 				},
 				{
-					"listen": "test",
-					"script": {
-						"type": "text/javascript",
-						"exec": [
-							""
-						]
-					}
-				}
-			]
+					"name": "Query Sub-account List (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/list?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"list"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "isFreeze",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "1",
+									"description": "Default 1; max 200",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Sub-account Spot Asset Transfer History (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/sub/transfer/history?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"sub",
+								"transfer",
+								"history"
+							],
+							"query": [
+								{
+									"key": "fromEmail",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "toEmail",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- fromEmail and toEmail cannot be sent at the same time.\n- Return fromEmail equal master account email by default.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Sub-account Futures Asset Transfer History (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?email=&futuresType=2&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"futures",
+								"internalTransfer"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "futuresType",
+									"value": "2",
+									"description": "1:USDT-margined Futures, 2: Coin-margined Futures"
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"description": "Default value: 50, Max value: 500",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Sub-account Futures Asset Transfer (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?fromEmail=&toEmail=&futuresType=2&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"futures",
+								"internalTransfer"
+							],
+							"query": [
+								{
+									"key": "fromEmail",
+									"value": "",
+									"description": "Sender email"
+								},
+								{
+									"key": "toEmail",
+									"value": "",
+									"description": "Recipient email"
+								},
+								{
+									"key": "futuresType",
+									"value": "2",
+									"description": "1:USDT-margined Futures,2: Coin-margined Futures"
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- Master account can transfer max 2000 times a minute\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Sub-account Assets (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v3/sub-account/assets?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v3",
+								"sub-account",
+								"assets"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch sub-account assets\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Sub-account Spot Assets Summary (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/spotSummary?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"spotSummary"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "size",
+									"value": "",
+									"description": "Default:10 Max:20",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Get BTC valued asset summary of subaccounts.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Sub-account Deposit Address (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/deposit/subAddress?email=&coin=BNB&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"deposit",
+								"subAddress"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "coin",
+									"value": "BNB",
+									"description": "Coin name"
+								},
+								{
+									"key": "network",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch sub-account deposit address\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Sub-account Deposit History (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/deposit/subHisrec?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"deposit",
+								"subHisrec"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "coin",
+									"value": "BNB",
+									"description": "Coin name",
+									"disabled": true
+								},
+								{
+									"key": "status",
+									"value": "",
+									"description": "0(0:pending,6: credited but cannot withdraw, 1:success)",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "offset",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch sub-account deposit history\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Sub-account's Status on Margin/Futures (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/status?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"status"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- If no `email` sent, all sub-accounts' information will be returned.\n\nWeight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Enable Margin for Sub-account (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/margin/enable?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"margin",
+								"enable"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Detail on Sub-account's Margin Account (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/margin/account?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"margin",
+								"account"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Summary of Sub-account's Margin Account (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/margin/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"margin",
+								"accountSummary"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Enable Futures for Sub-account (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/futures/enable?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"futures",
+								"enable"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Detail on Sub-account's Futures Account (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/futures/account?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"futures",
+								"account"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Summary of Sub-account's Futures Account (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/futures/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"futures",
+								"accountSummary"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Futures Position-Risk of Sub-account (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/futures/positionRisk?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"futures",
+								"positionRisk"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Futures Transfer for Sub-account (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/futures/transfer?email=&asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"futures",
+								"transfer"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "type",
+									"value": "",
+									"description": "* `1` - transfer from subaccount's spot account to its USDT-margined futures account\n* `2` - transfer from subaccount's USDT-margined futures account to its spot account\n* `3` - transfer from subaccount's spot account to its COIN-margined futures account\n* `4` - transfer from subaccount's COIN-margined futures account to its spot account"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Margin Transfer for Sub-account (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/margin/transfer?email=&asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"margin",
+								"transfer"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "type",
+									"value": "",
+									"description": "* `1` - transfer from subaccount's spot account to margin account\n* `2` - transfer from subaccount's margin account to its spot account"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Transfer to Sub-account of Same Master (For Sub-account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/transfer/subToSub?toEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"transfer",
+								"subToSub"
+							],
+							"query": [
+								{
+									"key": "toEmail",
+									"value": "",
+									"description": "Recipient email"
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Transfer to Master (For Sub-account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/transfer/subToMaster?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"transfer",
+								"subToMaster"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Sub-account Transfer History (For Sub-account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/transfer/subUserHistory?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"transfer",
+								"subUserHistory"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BNB",
+									"disabled": true
+								},
+								{
+									"key": "type",
+									"value": "",
+									"description": "* `1` - transfer in\n* `2` - transfer out",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- If `type` is not sent, the records of type 2: transfer out will be returned by default.\n- If `startTime` and `endTime` are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Universal Transfer History (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/universalTransfer?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"universalTransfer"
+							],
+							"query": [
+								{
+									"key": "fromEmail",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "toEmail",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "clientTranId",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"description": "Default 500, Max 500",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- `fromEmail` and `toEmail` cannot be sent at the same time.\n- Return `fromEmail` equal master account email by default.\n- The query time period must be less then 30 days.\n- If startTime and endTime not sent, return records of the last 30 days by default.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Universal Transfer (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/universalTransfer?fromAccountType=&toAccountType=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"universalTransfer"
+							],
+							"query": [
+								{
+									"key": "fromEmail",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "toEmail",
+									"value": "",
+									"description": "Sub-account email",
+									"disabled": true
+								},
+								{
+									"key": "fromAccountType",
+									"value": ""
+								},
+								{
+									"key": "toAccountType",
+									"value": ""
+								},
+								{
+									"key": "clientTranId",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "symbol",
+									"value": "",
+									"description": "Only supported under ISOLATED_MARGIN type",
+									"disabled": true
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- You need to enable \"internal transfer\" option for the api key which requests this endpoint.\n- Transfer from master account by default if fromEmail is not sent.\n- Transfer to master account by default if toEmail is not sent.\n- Transfer between futures accounts is not supported.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Detail on Sub-account's Futures Account V2 (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v2/sub-account/futures/account?email=&futuresType=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v2",
+								"sub-account",
+								"futures",
+								"account"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "futuresType",
+									"value": "",
+									"description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Summary of Sub-account's Futures Account V2 (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v2/sub-account/futures/accountSummary?futuresType=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v2",
+								"sub-account",
+								"futures",
+								"accountSummary"
+							],
+							"query": [
+								{
+									"key": "futuresType",
+									"value": "",
+									"description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
+								},
+								{
+									"key": "page",
+									"value": "1",
+									"description": "Default 1",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"description": "Default 10, Max 20",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Futures Position-Risk of Sub-account V2 (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v2/sub-account/futures/positionRisk?email=&futuresType=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v2",
+								"sub-account",
+								"futures",
+								"positionRisk"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "futuresType",
+									"value": "",
+									"description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Enable Leverage Token for Sub-account (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/blvt/enable?email=&enableBlvt=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"blvt",
+								"enable"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "enableBlvt",
+									"value": "",
+									"description": "Only true for now"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Deposit assets into the managed sub-account (For Investor Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/managed-subaccount/deposit?toEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"managed-subaccount",
+								"deposit"
+							],
+							"query": [
+								{
+									"key": "toEmail",
+									"value": "",
+									"description": "Recipient email"
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query managed sub-account asset details (For Investor Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/managed-subaccount/asset?email=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"managed-subaccount",
+								"asset"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Withdrawl assets from the managed sub-account (For Investor Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/managed-subaccount/withdraw?fromEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"managed-subaccount",
+								"withdraw"
+							],
+							"query": [
+								{
+									"key": "fromEmail",
+									"value": "",
+									"description": "Sender email"
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "transferDate",
+									"value": "",
+									"description": "Withdrawals is automatically occur on the transfer date(UTC0). If a date is not selected, the withdrawal occurs right now",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query managed sub-account snapshot (For Investor Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/managed-subaccount/accountSnapshot?email=testaccount@email.com&type=SPOT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"managed-subaccount",
+								"accountSnapshot"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "testaccount@email.com"
+								},
+								{
+									"key": "type",
+									"value": "SPOT",
+									"description": "\"SPOT\", \"MARGIN\"（cross）, \"FUTURES\"（UM）"
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"description": "min 7, max 30, default 7",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- The query time period must be less then 30 days\n- Support query within the last one month only\n- If `startTime` and `endTime` not sent, return records of the last 7 days by default\n\nWeight(IP): 2400"
+					},
+					"response": []
+				},
+				{
+					"name": "Enable or Disable IP Restriction for a Sub-account API Key (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&ipRestrict=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"subAccountApi",
+								"ipRestriction"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "subAccountApiKey",
+									"value": ""
+								},
+								{
+									"key": "ipRestrict",
+									"value": "",
+									"description": "true or false"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(UID): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Get IP Restriction for a Sub-account API Key (For Master Account)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"subAccountApi",
+								"ipRestriction"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "subAccountApiKey",
+									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(UID): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Add IP List for a Sub-account API Key (For Master Account)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"subAccountApi",
+								"ipRestriction",
+								"ipList"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "subAccountApiKey",
+									"value": ""
+								},
+								{
+									"key": "ipAddress",
+									"value": "",
+									"description": "Can be added in batches, separated by commas"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Before the usage of this endpoint, please ensure `POST /sapi/v1/sub-account/subAccountApi/ipRestriction` was used to enable the IP restriction.\n\nWeight(UID): 3000"
+					},
+					"response": []
+				},
+				{
+					"name": "Delete IP List for a Sub-account API Key (For Master Account)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"sub-account",
+								"subAccountApi",
+								"ipRestriction",
+								"ipList"
+							],
+							"query": [
+								{
+									"key": "email",
+									"value": "",
+									"description": "Sub-account email"
+								},
+								{
+									"key": "subAccountApiKey",
+									"value": ""
+								},
+								{
+									"key": "ipAddress",
+									"value": "",
+									"description": "Can be added in batches, separated by commas"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(UID): 3000"
+					},
+					"response": []
+				}],
+			"description": "Sub-account Endpoints"
 		},
-		{
+			{
 			"name": "Trade",
 			"item": [
 				{
@@ -10972,12 +11796,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/order/test?symbol=BTCUSDT&side=SELL&type=LIMIT&quantity=0.01&price=9000&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/api/v3/order/test?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -10990,7 +11814,8 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "side",
@@ -10998,248 +11823,82 @@
 								},
 								{
 									"key": "type",
-									"value": "LIMIT"
+									"value": "",
+									"description": "Order type"
 								},
 								{
 									"key": "timeInForce",
-									"value": "GTC",
+									"value": "",
+									"description": "Order time in force",
 									"disabled": true
 								},
 								{
 									"key": "quantity",
-									"value": "0.01"
+									"value": "",
+									"description": "Order quantity",
+									"disabled": true
 								},
 								{
 									"key": "quoteOrderQty",
-									"value": null,
+									"value": "",
+									"description": "Quote quantity",
 									"disabled": true
 								},
 								{
 									"key": "price",
-									"value": "9000"
+									"value": "",
+									"description": "Order price",
+									"disabled": true
 								},
 								{
 									"key": "newClientOrderId",
-									"value": "my_order_id_1",
+									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
 									"disabled": true
 								},
 								{
 									"key": "stopPrice",
-									"value": null,
+									"value": "",
+									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+									"disabled": true
+								},
+								{
+									"key": "trailingDelta",
+									"value": "",
+									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
 									"disabled": true
 								},
 								{
 									"key": "icebergQty",
-									"value": null,
+									"value": "",
+									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
 									"disabled": true
 								},
 								{
 									"key": "newOrderRespType",
-									"value": null,
+									"value": "",
+									"description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "New Order",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order?symbol=BTCUSDT&side=SELL&type=LIMIT&quantity=0.01&price=9000&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BTCUSDT"
-								},
-								{
-									"key": "side",
-									"value": "SELL"
-								},
-								{
-									"key": "type",
-									"value": "LIMIT"
-								},
-								{
-									"key": "timeInForce",
-									"value": "GTC",
-									"disabled": true
-								},
-								{
-									"key": "quantity",
-									"value": "0.01"
-								},
-								{
-									"key": "quoteOrderQty",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": "9000"
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "my_order_id_1",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "icebergQty",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel Order",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order?symbol=BTCUSDT&orderId&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BTCUSDT"
-								},
-								{
-									"key": "orderId",
-									"value": null
-								},
-								{
-									"key": "origClientOrderId",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel all Open Orders on a Symbol (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/openOrders?symbol=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"openOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": ""
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
+						},
+						"description": "Test new order creation and signature/recvWindow long.\nCreates and validates a new order but does not send it into the matching engine.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -11255,12 +11914,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/order?symbol=BTCUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/api/v3/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -11272,28 +11931,229 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "orderId",
 									"value": "",
+									"description": "Order id",
 									"disabled": true
 								},
 								{
 									"key": "origClientOrderId",
-									"value": null,
+									"value": "",
+									"description": "Order id from client",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Check an order's status.\n\n- Either `orderId` or `origClientOrderId` must be sent.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 2"
+					},
+					"response": []
+				},
+				{
+					"name": "New Order (TRADE)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/order?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"order"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "side",
+									"value": "SELL"
+								},
+								{
+									"key": "type",
+									"value": "",
+									"description": "Order type"
+								},
+								{
+									"key": "timeInForce",
+									"value": "",
+									"description": "Order time in force",
+									"disabled": true
+								},
+								{
+									"key": "quantity",
+									"value": "",
+									"description": "Order quantity",
+									"disabled": true
+								},
+								{
+									"key": "quoteOrderQty",
+									"value": "",
+									"description": "Quote quantity",
+									"disabled": true
+								},
+								{
+									"key": "price",
+									"value": "",
+									"description": "Order price",
+									"disabled": true
+								},
+								{
+									"key": "newClientOrderId",
+									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
+									"disabled": true
+								},
+								{
+									"key": "stopPrice",
+									"value": "20.01",
+									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+									"disabled": true
+								},
+								{
+									"key": "trailingDelta",
+									"value": "20.01",
+									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+									"disabled": true
+								},
+								{
+									"key": "icebergQty",
+									"value": "",
+									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
+									"disabled": true
+								},
+								{
+									"key": "newOrderRespType",
+									"value": "",
+									"description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Send in a new order.\n\n- `LIMIT_MAKER` are `LIMIT` orders that will be rejected if they would immediately match and trade as a taker.\n- `STOP_LOSS` and `TAKE_PROFIT` will execute a `MARKET` order when the `stopPrice` is reached.\n- Any `LIMIT` or `LIMIT_MAKER` type order can be made an iceberg order by sending an `icebergQty`.\n- Any order with an `icebergQty` MUST have `timeInForce` set to `GTC`.\n- `MARKET` orders using `quantity` specifies how much a user wants to buy or sell based on the market price.\n- `MARKET` orders using `quoteOrderQty` specifies the amount the user wants to spend (when buying) or receive (when selling) of the quote asset; the correct quantity will be determined based on the market liquidity and `quoteOrderQty`.\n- `MARKET` orders using `quoteOrderQty` will not break `LOT_SIZE` filter rules; the order will execute a quantity that will have the notional value as close as possible to `quoteOrderQty`.\n- same `newClientOrderId` can be accepted only when the previous one is filled, otherwise the order will be rejected.\n\nTrigger order price rules against market price for both `MARKET` and `LIMIT` versions:\n\n- Price above market price: `STOP_LOSS` `BUY`, `TAKE_PROFIT` `SELL`\n- Price below market price: `STOP_LOSS` `SELL`, `TAKE_PROFIT` `BUY`\n\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel Order (TRADE)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"order"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "orderId",
+									"value": "",
+									"description": "Order id",
+									"disabled": true
+								},
+								{
+									"key": "origClientOrderId",
+									"value": "",
+									"description": "Order id from client",
+									"disabled": true
+								},
+								{
+									"key": "newClientOrderId",
+									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Cancel an active order.\n\nEither `orderId` or `origClientOrderId` must be sent.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -11309,8 +12169,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -11326,19 +12186,83 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get all open orders on a symbol. Careful when accessing this with no symbol.\n\nWeight(IP):\n- `3` for a single symbol;\n- `40` when the symbol parameter is omitted;"
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel all Open Orders on a Symbol (TRADE)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/openOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"openOrders"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Cancels all active orders on a symbol.\nThis includes OCO orders.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -11354,12 +12278,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/allOrders?symbol=BTCUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/api/v3/allOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -11371,38 +12295,52 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "orderId",
-									"value": null,
+									"value": "",
+									"description": "Order id",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get all account orders; active, canceled, or filled..\n\n- If `orderId` is set, it will get orders >= that `orderId`. Otherwise most recent orders are returned.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n- If `startTime` and/or `endTime` provided, `orderId` is not required\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -11418,12 +12356,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/order/oco?symbol=BTCUSDT&side=&quantity=&price&stopPrice&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/api/v3/order/oco?symbol=BNBUSDT&side=SELL&quantity=&price=&stopPrice=&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -11436,16 +12374,18 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "listClientOrderId",
-									"value": null,
+									"value": "",
+									"description": "A unique Id for the entire orderList",
 									"disabled": true
 								},
 								{
 									"key": "side",
-									"value": ""
+									"value": "SELL"
 								},
 								{
 									"key": "quantity",
@@ -11453,116 +12393,76 @@
 								},
 								{
 									"key": "limitClientOrderId",
-									"value": null,
+									"value": "",
+									"description": "A unique Id for the limit order",
 									"disabled": true
 								},
 								{
 									"key": "price",
-									"value": null
+									"value": "",
+									"description": "Order price"
 								},
 								{
 									"key": "limitIcebergQty",
-									"value": null,
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "trailingDelta",
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "stopClientOrderId",
-									"value": null,
+									"value": "",
+									"description": "A unique Id for the stop loss/stop loss limit leg",
 									"disabled": true
 								},
 								{
 									"key": "stopPrice",
-									"value": null
+									"value": ""
 								},
 								{
 									"key": "stopLimitPrice",
-									"value": null,
+									"value": "",
+									"description": "If provided, stopLimitTimeInForce is required.",
 									"disabled": true
 								},
 								{
 									"key": "stopIcebergQty",
-									"value": null,
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "stopLimitTimeInForce",
-									"value": null,
+									"value": "",
 									"disabled": true
 								},
 								{
 									"key": "newOrderRespType",
-									"value": null,
+									"value": "",
+									"description": "Set the response JSON.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel OCO (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/orderList?symbol=BTCUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"orderList"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BTCUSDT"
-								},
-								{
-									"key": "orderListId",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "listClientOrderId",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": null,
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}"
-								}
-							]
-						}
+						},
+						"description": "Send in a new OCO\n\n- Price Restrictions:\n  - `SELL`: Limit Price > Last Price > Stop Price\n  - `BUY`: Limit Price < Last Price < Stop Price\n- Quantity Restrictions:\n    - Both legs must have the same quantity\n    - `ICEBERG` quantities however do not have to be the same\n- Order Rate Limit\n    - `OCO` counts as 2 orders against the order rate limit.\n    \nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -11578,8 +12478,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -11595,24 +12495,107 @@
 							"query": [
 								{
 									"key": "orderListId",
-									"value": null,
+									"value": "",
+									"description": "Order list id",
 									"disabled": true
 								},
 								{
 									"key": "origClientOrderId",
-									"value": null,
+									"value": "",
+									"description": "Order id from client",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Retrieves a specific OCO based on provided optional parameters\n\nWeight(IP): 2"
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel OCO (TRADE)",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/orderList?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"orderList"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "orderListId",
+									"value": "",
+									"description": "Order list id",
+									"disabled": true
+								},
+								{
+									"key": "listClientOrderId",
+									"value": "",
+									"description": "A unique Id for the entire orderList",
+									"disabled": true
+								},
+								{
+									"key": "newClientOrderId",
+									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Cancel an entire Order List\n\nCanceling an individual leg will cancel the entire OCO\n\nWeight(IP): 1"
 					},
 					"response": []
 				},
@@ -11628,8 +12611,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -11645,34 +12628,47 @@
 							"query": [
 								{
 									"key": "fromId",
-									"value": null,
+									"value": "",
+									"description": "Trade id to fetch from. Default gets most recent trades.",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Retrieves all OCO based on provided optional parameters\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -11688,8 +12684,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -11704,15 +12700,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Weight(IP): 3"
 					},
 					"response": []
 				},
@@ -11728,8 +12733,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -11744,15 +12749,24 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get current account information.\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -11768,12 +12782,12 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/myTrades?symbol=BTCUSDT&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/api/v3/myTrades?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -11785,44 +12799,58 @@
 							"query": [
 								{
 									"key": "symbol",
-									"value": "BTCUSDT"
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
 								},
 								{
 									"key": "orderId",
-									"value": null,
-									"description": "This can only be used in combination with symbol",
+									"value": "",
+									"description": "This can only be used in combination with symbol.",
 									"disabled": true
 								},
 								{
 									"key": "startTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "endTime",
-									"value": null,
+									"value": "",
+									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
 									"key": "fromId",
-									"value": null,
+									"value": "",
+									"description": "Trade id to fetch from. Default gets most recent trades.",
 									"disabled": true
 								},
 								{
 									"key": "limit",
 									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Get trades for a specific account and symbol.\n\nIf `fromId` is set, it will get id >= that `fromId`. Otherwise most recent orders are returned.\n\nWeight(IP): 10"
 					},
 					"response": []
 				},
@@ -11838,8 +12866,8 @@
 							},
 							{
 								"key": "X-MBX-APIKEY",
-								"type": "text",
-								"value": "{{binance-api-key}}"
+								"value": "{{binance-api-key}}",
+								"type": "text"
 							}
 						],
 						"url": {
@@ -11855,30 +12883,39 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}"
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}"
+									"value": "{{signature}}",
+									"description": "Signature"
 								}
 							]
-						}
+						},
+						"description": "Displays the user's current order count usage for all intervals.\n\nWeight(IP): 20"
 					},
 					"response": []
-				}
-			]
+				}],
+			"description": "Account/Trade"
 		},
-		{
-			"name": "v2",
+			{
+			"name": "User Data Stream",
 			"item": [
 				{
-					"name": "Corporate ( sub-account )",
+					"name": "Spot",
 					"item": [
 						{
-							"name": "Get Detail on Sub-account's Futures Account V2 (For Master Account)",
+							"name": "Create a ListenKey (USER_STREAM)",
 							"request": {
-								"method": "GET",
+								"method": "POST",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -11887,49 +12924,29 @@
 									},
 									{
 										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
+										"value": "{{binance-api-key}}",
+										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{url}}/sapi/v2/sub-account/futures/account?email=&futuresType=1&timestamp={{timestamp}}&signature={{signature}}",
+									"raw": "{{url}}/api/v3/userDataStream",
 									"host": [
 										"{{url}}"
 									],
 									"path": [
-										"sapi",
-										"v2",
-										"sub-account",
-										"futures",
-										"account"
-									],
-									"query": [
-										{
-											"key": "email",
-											"value": ""
-										},
-										{
-											"key": "futuresType",
-											"value": "1",
-											"description": "1:USDT Margined Futures, 2:COIN Margined Futures"
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
-										}
+										"api",
+										"v3",
+										"userDataStream"
 									]
-								}
+								},
+								"description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
 							},
 							"response": []
 						},
 						{
-							"name": "Get Summary of Sub-account's Futures Account V2 (For Master Account)",
+							"name": "Ping/Keep-alive a ListenKey (USER_STREAM)",
 							"request": {
-								"method": "GET",
+								"method": "PUT",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -11938,54 +12955,37 @@
 									},
 									{
 										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
+										"value": "{{binance-api-key}}",
+										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{url}}/sapi/v2/sub-account/futures/accountSummary?futuresType=&page=1&limit=10&timestamp={{timestamp}}&signature={{signature}}",
+									"raw": "{{url}}/api/v3/userDataStream",
 									"host": [
 										"{{url}}"
 									],
 									"path": [
-										"sapi",
-										"v2",
-										"sub-account",
-										"futures",
-										"accountSummary"
+										"api",
+										"v3",
+										"userDataStream"
 									],
 									"query": [
 										{
-											"key": "futuresType",
-											"value": "",
-											"description": "1:USDT Margined Futures, 2:COIN Margined Futures"
-										},
-										{
-											"key": "page",
-											"value": "1"
-										},
-										{
-											"key": "limit",
-											"value": "10",
-											"description": "default:10, max:20"
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
+											"key": "listenKey",
+											"value": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1",
+											"description": "User websocket listen key",
+											"disabled": true
 										}
 									]
-								}
+								},
+								"description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
 							},
 							"response": []
 						},
 						{
-							"name": "Get Futures Postion-Risk of Sub-account V2 (For Master Account)",
+							"name": "Close a ListenKey (USER_STREAM)",
 							"request": {
-								"method": "GET",
+								"method": "DELETE",
 								"header": [
 									{
 										"key": "Content-Type",
@@ -11994,48 +12994,1583 @@
 									},
 									{
 										"key": "X-MBX-APIKEY",
-										"type": "text",
-										"value": "{{binance-api-key}}"
+										"value": "{{binance-api-key}}",
+										"type": "text"
 									}
 								],
 								"url": {
-									"raw": "{{url}}/sapi/v2/sub-account/futures/positionRisk?email=&futuresType=1&timestamp={{timestamp}}&signature={{signature}}",
+									"raw": "{{url}}/api/v3/userDataStream",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"v3",
+										"userDataStream"
+									],
+									"query": [
+										{
+											"key": "listenKey",
+											"value": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1",
+											"description": "User websocket listen key",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Close out a user data stream.\n\nWeight: 1"
+							},
+							"response": []
+						}],
+					"description": "User Data Stream"
+				},
+				{
+					"name": "Cross Margin",
+					"item": [
+						{
+							"name": "Create a ListenKey (USER_STREAM)",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-MBX-APIKEY",
+										"value": "{{binance-api-key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/sapi/v1/userDataStream",
 									"host": [
 										"{{url}}"
 									],
 									"path": [
 										"sapi",
-										"v2",
-										"sub-account",
-										"futures",
-										"positionRisk"
+										"v1",
+										"userDataStream"
+									]
+								},
+								"description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
+							},
+							"response": []
+						},
+						{
+							"name": "Ping/Keep-alive a ListenKey (USER_STREAM)",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-MBX-APIKEY",
+										"value": "{{binance-api-key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/sapi/v1/userDataStream",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"sapi",
+										"v1",
+										"userDataStream"
 									],
 									"query": [
 										{
-											"key": "email",
-											"value": ""
-										},
-										{
-											"key": "futuresType",
-											"value": "1",
-											"description": "1:USDT Margined Futures, 2:COIN Margined Futures"
-										},
-										{
-											"key": "timestamp",
-											"value": "{{timestamp}}"
-										},
-										{
-											"key": "signature",
-											"value": "{{signature}}"
+											"key": "listenKey",
+											"value": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1",
+											"description": "User websocket listen key",
+											"disabled": true
 										}
 									]
-								}
+								},
+								"description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
 							},
 							"response": []
-						}
-					]
-				}
-			]
+						},
+						{
+							"name": "Close a ListenKey (USER_STREAM)",
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-MBX-APIKEY",
+										"value": "{{binance-api-key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/sapi/v1/userDataStream",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"sapi",
+										"v1",
+										"userDataStream"
+									],
+									"query": [
+										{
+											"key": "listenKey",
+											"value": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1",
+											"description": "User websocket listen key",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Close out a user data stream.\n\nWeight: 1"
+							},
+							"response": []
+						}],
+					"description": "Margin User Data Stream"
+				},
+				{
+					"name": "Isolated Margin",
+					"item": [
+						{
+							"name": "Generate a Listen Key (USER_STREAM)",
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-MBX-APIKEY",
+										"value": "{{binance-api-key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/sapi/v1/userDataStream/isolated",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"sapi",
+										"v1",
+										"userDataStream",
+										"isolated"
+									]
+								},
+								"description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
+							},
+							"response": []
+						},
+						{
+							"name": "Ping/Keep-alive a Listen Key (USER_STREAM)",
+							"request": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-MBX-APIKEY",
+										"value": "{{binance-api-key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/sapi/v1/userDataStream/isolated",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"sapi",
+										"v1",
+										"userDataStream",
+										"isolated"
+									],
+									"query": [
+										{
+											"key": "listenKey",
+											"value": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1",
+											"description": "User websocket listen key",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
+							},
+							"response": []
+						},
+						{
+							"name": "Close a ListenKey (USER_STREAM)",
+							"request": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Content-Type",
+										"type": "text",
+										"value": "application/json"
+									},
+									{
+										"key": "X-MBX-APIKEY",
+										"value": "{{binance-api-key}}",
+										"type": "text"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/sapi/v1/userDataStream/isolated",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"sapi",
+										"v1",
+										"userDataStream",
+										"isolated"
+									],
+									"query": [
+										{
+											"key": "listenKey",
+											"value": "pqia91ma19a5s61cv6a81va65sdf19v8a65a1a5s61cv6a81va65sdf19v8a65a1",
+											"description": "User websocket listen key",
+											"disabled": true
+										}
+									]
+								},
+								"description": "Close out a user data stream.\n\nWeight: 1"
+							},
+							"response": []
+						}],
+					"description": "Isolated User Data Stream"
+				}],
+			"description": ""
+		},
+			{
+			"name": "Wallet",
+			"item": [
+				{
+					"name": "System Status (System)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/system/status",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"system",
+								"status"
+							]
+						},
+						"description": "Fetch system status.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "All Coins' Information (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/config/getall?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"config",
+								"getall"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Get information of coins (available for deposit and withdraw) for user.\n\nWeight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Daily Account Snapshot (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/accountSnapshot?type=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"accountSnapshot"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": ""
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- The query time period must be less than 30 days\n- Support query within the last one month only\n- If startTimeand endTime not sent, return records of the last 7 days by default\n\nWeight(IP): 2400"
+					},
+					"response": []
+				},
+				{
+					"name": "Disable Fast Withdraw Switch (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/account/disableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"account",
+								"disableFastWithdrawSwitch"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- This request will disable fastwithdraw switch under your account.\n- You need to enable \"trade\" option for the api key which requests this endpoint.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Enable Fast Withdraw Switch (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/account/enableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"account",
+								"enableFastWithdrawSwitch"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- This request will enable fastwithdraw switch under your account. You need to enable \"trade\" option for the api key which requests this endpoint.\n- When Fast Withdraw Switch is on, transferring funds to a Binance account will be done instantly. There is no on-chain transaction, no transaction ID and no withdrawal fee.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Withdraw (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/withdraw/apply?coin=BNB&address=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"withdraw",
+								"apply"
+							],
+							"query": [
+								{
+									"key": "coin",
+									"value": "BNB",
+									"description": "Coin name"
+								},
+								{
+									"key": "withdrawOrderId",
+									"value": "",
+									"description": "Client id for withdraw",
+									"disabled": true
+								},
+								{
+									"key": "network",
+									"value": "",
+									"description": "Get the value from `GET /sapi/v1/capital/config/getall`",
+									"disabled": true
+								},
+								{
+									"key": "address",
+									"value": ""
+								},
+								{
+									"key": "addressTag",
+									"value": "",
+									"description": "Secondary address identifier for coins like XRP,XMR etc.",
+									"disabled": true
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "transactionFeeFlag",
+									"value": "",
+									"description": "When making internal transfer\n- `true` ->  returning the fee to the destination account;\n- `false` -> returning the fee back to the departure account.",
+									"disabled": true
+								},
+								{
+									"key": "name",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "walletType",
+									"value": "",
+									"description": "The wallet type for withdraw，0-Spot wallet, 1- Funding wallet. Default is Spot wallet",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Submit a withdraw request.\n\n- If `network` not send, return with default network of the coin.\n- You can get `network` and `isDefault` in `networkList` of a coin in the response of `Get /sapi/v1/capital/config/getall (HMAC SHA256)`.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Deposit History (supporting network)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/deposit/hisrec?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"deposit",
+								"hisrec"
+							],
+							"query": [
+								{
+									"key": "coin",
+									"value": "BNB",
+									"description": "Coin name",
+									"disabled": true
+								},
+								{
+									"key": "status",
+									"value": "",
+									"description": "* `0` - pending\n* `6` - credited but cannot withdraw\n* `1` - success",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "offset",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch deposit history.\n\n- Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.\n- If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Withdraw History (supporting network)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/withdraw/history?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"withdraw",
+								"history"
+							],
+							"query": [
+								{
+									"key": "coin",
+									"value": "BNB",
+									"description": "Coin name",
+									"disabled": true
+								},
+								{
+									"key": "withdrawOrderId",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "status",
+									"value": "",
+									"description": "* `0` - Email Sent\n* `1` - Cancelled\n* `2` - Awaiting Approval\n* `3` - Rejected\n* `4` - Processing\n* `5` - Failure\n* `6` - Completed",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "offset",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "500",
+									"description": "Default 500; max 1000.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch withdraw history.\n\n- `network` may not be in the response for old withdraw.\n- Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.\n- If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Deposit Address (supporting network)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/deposit/address?coin=BNB&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"deposit",
+								"address"
+							],
+							"query": [
+								{
+									"key": "coin",
+									"value": "BNB",
+									"description": "Coin name"
+								},
+								{
+									"key": "network",
+									"value": "ETH",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch deposit address with network.\n\n- If network is not send, return with default network of the coin.\n- You can get network and isDefault in networkList in the response of Get /sapi/v1/capital/config/getall (HMAC SHA256).\n\nWeight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Account Status (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/account/status?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"account",
+								"status"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch account status detail.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Account API Trading Status (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/account/apiTradingStatus?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"account",
+								"apiTradingStatus"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch account API trading status with details.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "DustLog (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/dribblet?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"dribblet"
+							],
+							"query": [
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get Assets That Can Be Converted Into BNB (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/dust-btc?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"dust-btc"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Dust Transfer (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/dust?asset=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"dust"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "",
+									"description": "The asset being converted. For example, asset=BTC&asset=USDT"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Convert dust assets to BNB.\n\nWeight(UID): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Asset Dividend Record (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/assetDividend?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"assetDividend"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BNB",
+									"disabled": true
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Query asset Dividend Record\n\nWeight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Asset Detail (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/assetDetail?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"assetDetail"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BNB",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch details of assets supported on Binance.\n\n- Please get network and other deposit or withdraw details from `GET /sapi/v1/capital/config/getall`.\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Trade Fee (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/tradeFee?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"tradeFee"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Fetch trade fee\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Query User Universal Transfer History (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/transfer?type=MAIN_C2C&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"transfer"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "MAIN_C2C",
+									"description": "Universal transfer type"
+								},
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "current",
+									"value": "1",
+									"description": "Current querying page. Start from 1. Default:1",
+									"disabled": true
+								},
+								{
+									"key": "size",
+									"value": "100",
+									"description": "Default:10 Max:100",
+									"disabled": true
+								},
+								{
+									"key": "fromSymbol",
+									"value": "BNBUSDT",
+									"description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+									"disabled": true
+								},
+								{
+									"key": "toSymbol",
+									"value": "BNBUSDT",
+									"description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- Support query within the last 6 months only\n- If `startTime` and `endTime` not sent, return records of the last 7 days by default\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "User Universal Transfer (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/transfer?type=MAIN_C2C&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"transfer"
+							],
+							"query": [
+								{
+									"key": "type",
+									"value": "MAIN_C2C",
+									"description": "Universal transfer type"
+								},
+								{
+									"key": "asset",
+									"value": "BTC"
+								},
+								{
+									"key": "amount",
+									"value": "1.01"
+								},
+								{
+									"key": "fromSymbol",
+									"value": "BNBUSDT",
+									"description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+									"disabled": true
+								},
+								{
+									"key": "toSymbol",
+									"value": "BNBUSDT",
+									"description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "You need to enable `Permits Universal Transfer` option for the api key which requests this endpoint.\n\n- `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n\nENUM of transfer types:\n- MAIN_UMFUTURE Spot account transfer to USDⓈ-M Futures account\n- MAIN_CMFUTURE Spot account transfer to COIN-M Futures account\n- MAIN_MARGIN Spot account transfer to Margin（cross）account\n- UMFUTURE_MAIN USDⓈ-M Futures account transfer to Spot account\n- UMFUTURE_MARGIN USDⓈ-M Futures account transfer to Margin（cross）account\n- CMFUTURE_MAIN COIN-M Futures account transfer to Spot account\n- CMFUTURE_MARGIN COIN-M Futures account transfer to Margin(cross) account\n- MARGIN_MAIN Margin（cross）account transfer to Spot account\n- MARGIN_UMFUTURE Margin（cross）account transfer to USDⓈ-M Futures\n- MARGIN_CMFUTURE Margin（cross）account transfer to COIN-M Futures\n- ISOLATEDMARGIN_MARGIN Isolated margin account transfer to Margin(cross) account\n- MARGIN_ISOLATEDMARGIN Margin(cross) account transfer to Isolated margin account\n- ISOLATEDMARGIN_ISOLATEDMARGIN Isolated margin account transfer to Isolated margin account\n- MAIN_FUNDING Spot account transfer to Funding account\n- FUNDING_MAIN Funding account transfer to Spot account\n- FUNDING_UMFUTURE Funding account transfer to UMFUTURE account\n- UMFUTURE_FUNDING UMFUTURE account transfer to Funding account\n- MARGIN_FUNDING MARGIN account transfer to Funding account\n- FUNDING_MARGIN Funding account transfer to Margin account\n- FUNDING_CMFUTURE Funding account transfer to CMFUTURE account\n- CMFUTURE_FUNDING CMFUTURE account transfer to Funding account\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Funding Wallet (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/asset/get-funding-asset?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"asset",
+								"get-funding-asset"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BNB",
+									"disabled": true
+								},
+								{
+									"key": "needBtcValuation",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "- Currently supports querying the following business assets：Binance Pay, Binance Card, Binance Gift Card, Stock Token\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "Get API Key Permission (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/account/apiRestrictions?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"account",
+								"apiRestrictions"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Weight(IP): 1"
+					},
+					"response": []
+				}],
+			"description": "Wallet Endpoints"
 		}
 	],
 	"event": [

--- a/collections/binance_vanilla_options_v1.postman_collection.json
+++ b/collections/binance_vanilla_options_v1.postman_collection.json
@@ -415,6 +415,12 @@
 							],
 							"query": [
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -470,6 +476,12 @@
 									"description": "Amount"
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -513,6 +525,12 @@
 									"key": "symbol",
 									"value": "",
 									"description": "Option trading pair",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -582,6 +600,12 @@
 									"key": "limit",
 									"value": "",
 									"description": "Number of result sets returned Default:100 Max:1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -681,6 +705,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -724,6 +754,12 @@
 									"key": "orders",
 									"value": "",
 									"description": "order list. Max 5 orders"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -780,6 +816,12 @@
 									"key": "clientOrderId",
 									"value": "",
 									"description": "User-defined order ID",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -840,6 +882,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -883,6 +931,12 @@
 									"key": "symbol",
 									"value": "",
 									"description": "Option trading pair"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",
@@ -939,6 +993,12 @@
 									"key": "clientOrderId",
 									"value": "",
 									"description": "User-defined order ID",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -1011,6 +1071,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1077,6 +1143,12 @@
 									"key": "limit",
 									"value": "",
 									"description": "Number of result sets returned Default:100 Max:1000",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
 									"disabled": true
 								},
 								{
@@ -1149,6 +1221,12 @@
 									"disabled": true
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1193,6 +1271,12 @@
 								"userDataStream"
 							],
 							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
 								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
@@ -1239,6 +1323,12 @@
 									"description": "listenKey"
 								},
 								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
 									"key": "timestamp",
 									"value": "{{timestamp}}"
 								},
@@ -1282,6 +1372,12 @@
 									"key": "listenKey",
 									"value": "",
 									"description": "listenKey"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
 								},
 								{
 									"key": "timestamp",


### PR DESCRIPTION
Renamed collections
-  `Blvt` to `BLVT`
- `Bswap` to `BSwap`
- `Corporate ( sub-account )` to `Sub-Account`

Refactored collections
- `Data Stream/Spot` to `Stream`
- `Data Stream/Margin/isolated` to `Isolated Margin Stream`
- `Data Stream/Margin/cross` to `Margin Stream`
- `Margin/isolated` to `Margin`
- `v2/Corporate ( sub-account )` to `Sub-Account`

Endpoints renamed
- Endpoint name schema `name (type)`

Updated collection, endpoint & query parameter descriptions

Added default values for parameters with a given example in the documentation

Reordered endpoint attributes to follow a standard
- Example: `X-MBX-APIKEY` header should follow `key, value, type` attribute order 

New endpoints
- Gift Card
  - `POST /sapi/v1/giftcard/createCode`
  - `GET /sapi/v1/giftcard/verify`
  - `POST /sapi/v1/giftcard/redeemCode`
- Wallet  
  - `POST /sapi/v1/asset/dust-btc`
- Futures Algo
  - `POST /sapi/v1/algo/futures/newOrderVp` to support VP new order
  - `DELETE /sapi/v1/algo/futures/order` to support cancel Algo order
  - `GET /sapi/v1/algo/futures/openOrders` to support query Algo open orders
  - `GET /sapi/v1/algo/futures/historicalOrders` to support query Algo historical orders
  - `GET /sapi/v1/algo/futures/subOrders` to support query Algo sub orders for a specified algoId

Changed endpoints
- `POST /sapi/v1/mining/hash-transfer/config` `startDate` and `endDate` parameter set to optional
- `GET /sapi/v1/lending/daily/product/list` added status parameter
- `GET /sapi/v1/sub-account/futures/internalTransfer` `futuresType` parameter set to required
- `GET /sapi/v1/sub-account/universalTransfer` & `POST /sapi/v1/sub-account/universalTransfer` added `clientTransId` parameter

Changed endpoints for Sub-account：
- `GET /sapi/v1/sub-account/universalTransfer`
The query time period must be less then 30 days; If `startTime` and  `endTime` not sent, return records of the last 30 days by default.
- `POST /sapi/v1/sub-account/universalTransfer`
New transfer types `MARGIN`, `ISOLATED_MARGIN` and parameter `symbol` added to support transfer to sub-account cross margin account and isolated margin account.
- `GET /sapi/v1/managed-subaccount/accountSnapshot`
New endpoint to support investor master account query asset snapshot of managed sub-account.

Changed endpoints for Spot Trading
- `POST /api/v3/order` - New optional field trailingDelta
- `POST /api/v3/order/test` - New optional field trailingDelta
- `POST /api/v3/order/oco` - New optional field trailingDelta

Removed redundant event script from `Savings` collection