### PR TITLE
release v1.3.0

### DIFF
--- a/collections/binance_spot_api_v1.postman_collection.json
+++ b/collections/binance_spot_api_v1.postman_collection.json
@@ -1612,7 +1612,7 @@
 								}
 							]
 						},
-						"description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
+						"description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(UID): 90000"
 					},
 					"response": []
 				},
@@ -7298,6 +7298,52 @@
 						"description": "Best price/qty on the order book for a symbol or symbols.\n\n- If the symbol is not sent, bookTickers for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `2` when the symbol parameter is omitted;"
 					},
 					"response": []
+				},
+				{
+					"name": "Rolling window price change statistics",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/ticker",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"ticker"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT",
+									"disabled": true
+								},
+								{
+									"key": "symbols",
+									"value": "",
+									"description": "Either symbol or symbols must be provided\nExamples of accepted format for the symbols parameter: [\"BTCUSDT\",\"BNBUSDT\"] or %5B%22BTCUSDT%22,%22BNBUSDT%22%5D.\n\nThe maximum number of symbols allowed in a request is 100.",
+									"disabled": true
+								},
+								{
+									"key": "windowSize",
+									"value": "",
+									"description": "Defaults to 1d if no parameter provided.\nSupported windowSize values:\n1m,2m....59m for minutes\n1h, 2h....23h - for hours\n1d...7d - for days.\n\nUnits cannot be combined (e.g. 1d2h is not allowed)",
+									"disabled": true
+								}
+							]
+						},
+						"description": "The window used to compute statistics is typically slightly wider than requested windowSize.\n\nopenTime for /api/v3/ticker always starts on a minute, while the closeTime is the current time of the request. As such, the effective window might be up to 1 minute wider than requested.\n\nE.g. If the closeTime is 1641287867099 (January 04, 2022 09:17:47:099 UTC) , and the windowSize is 1d. the openTime will be: 1641201420000 (January 3, 2022, 09:17:00 UTC)\n\nWeight(IP): 2 for each requested symbol regardless of windowSize.\n\nThe weight for this request will cap at 100 once the number of symbols in the request is more than 50."
+					},
+					"response": []
 				}],
 			"description": "Market Data"
 		},
@@ -8523,13 +8569,13 @@
 							],
 							"query": [
 								{
-									"key": "startTimestamp",
+									"key": "startTime",
 									"value": "",
 									"description": "UTC timestamp in ms",
 									"disabled": true
 								},
 								{
-									"key": "endTimestamp",
+									"key": "endTime",
 									"value": "",
 									"description": "UTC timestamp in ms",
 									"disabled": true
@@ -12729,6 +12775,147 @@
 							]
 						},
 						"description": "Check an order's status.\n\n- Either `orderId` or `origClientOrderId` must be sent.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 2"
+					},
+					"response": []
+				},
+				{
+					"name": "Cancel an Existing Order and Send a New Order (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/order/cancelReplace?symbol=BNBUSDT&side=SELL&type=&cancelReplaceMode=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"order",
+								"cancelReplace"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "side",
+									"value": "SELL"
+								},
+								{
+									"key": "type",
+									"value": "",
+									"description": "Order type"
+								},
+								{
+									"key": "cancelReplaceMode",
+									"value": "",
+									"description": "- `STOP_ON_FAILURE` If the cancel request fails, the new order placement will not be attempted.\n- `ALLOW_FAILURES` If new order placement will be attempted even if cancel request fails."
+								},
+								{
+									"key": "timeInForce",
+									"value": "",
+									"description": "Order time in force",
+									"disabled": true
+								},
+								{
+									"key": "quantity",
+									"value": "",
+									"description": "Order quantity",
+									"disabled": true
+								},
+								{
+									"key": "quoteOrderQty",
+									"value": "",
+									"description": "Quote quantity",
+									"disabled": true
+								},
+								{
+									"key": "price",
+									"value": "",
+									"description": "Order price",
+									"disabled": true
+								},
+								{
+									"key": "cancelNewClientOrderId",
+									"value": "",
+									"description": "Used to uniquely identify this cancel. Automatically generated by default",
+									"disabled": true
+								},
+								{
+									"key": "cancelOrigClientOrderId",
+									"value": "",
+									"description": "Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.",
+									"disabled": true
+								},
+								{
+									"key": "cancelOrderId",
+									"value": "",
+									"description": "Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.",
+									"disabled": true
+								},
+								{
+									"key": "newClientOrderId",
+									"value": "",
+									"description": "Used to identify the new order. Automatically generated by default",
+									"disabled": true
+								},
+								{
+									"key": "stopPrice",
+									"value": "20.01",
+									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+									"disabled": true
+								},
+								{
+									"key": "trailingDelta",
+									"value": "",
+									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+									"disabled": true
+								},
+								{
+									"key": "icebergQty",
+									"value": "",
+									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
+									"disabled": true
+								},
+								{
+									"key": "newOrderRespType",
+									"value": "",
+									"description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Cancels an existing order and places a new order on the same symbol.\n\nFilters are evaluated before the cancel order is placed.\n\nIf the new order placement is successfully sent to the engine, the order count will increase by 1.\n\nWeight(IP): 1"
 					},
 					"response": []
 				},


### PR DESCRIPTION
## Add

- `GET /api/v3/ticker` for rolling window price change statistics based on windowSize provided.
-  `POST /api/v3/order/cancelReplace` to cancel an existing order and place a new order on the same symbol.

## Update
 
- `GET /sapi/v1/fiat/orders`  Weight changes from IP to UID
- `GET /sapi/v1/pay/transactions` 
  - Param names changed: `startTimestamp` -> `startTime`; `endTimestamp` -> `endTime`.
