### PR TITLE
Rc-1.4.0

### DIFF
--- a/collections/binance_delivery_future_api_v1.postman_collection.json
+++ b/collections/binance_delivery_future_api_v1.postman_collection.json
@@ -3068,6 +3068,46 @@
 					"response": []
 				}
 			]
+		},
+		{
+			"name": "Portfolio Margin",
+			"item": [
+				{
+					"name": "Portfolio Margin Exchange Information",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/dapi/v1/pmExchangeInfo",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"dapi",
+								"v1",
+								"pmExchangeInfo"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"disabled": true
+								},
+								{
+									"key": "pair",
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
 		}
 	],
 	"event": [

--- a/collections/binance_perpetual_future_api_v1.postman_collection.json
+++ b/collections/binance_perpetual_future_api_v1.postman_collection.json
@@ -2984,6 +2984,127 @@
 					"response": []
 				},
 				{
+					"name": "Change Multi-Assets Mode (TRADE)",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"type": "text",
+								"value": "{{binance-api-key}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/fapi/v1/multiAssetsMargin?multiAssetsMargin=true&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"fapi",
+								"v1",
+								"multiAssetsMargin"
+							],
+							"query": [
+								{
+									"key": "multiAssetsMargin",
+									"value": "true",
+									"description": "\"true\": Multi-Assets Mode; \"false\": Single-Asset Mode"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Current Multi-Assets Mode (USER_DATA)",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"type": "text",
+								"value": "{{binance-api-key}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/fapi/v1/multiAssetsMargin?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"fapi",
+								"v1",
+								"multiAssetsMargin"
+							],
+							"query": [
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "User API Trading Quantitative Rules Indicators (USER_DATA)",
 					"event": [
 						{
@@ -3136,6 +3257,42 @@
 								"fapi",
 								"v1",
 								"listenKey"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Portfolio Margin",
+			"item": [
+				{
+					"name": "Portfolio Margin Exchange Information",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/fapi/v1/pmExchangeInfo",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"fapi",
+								"v1",
+								"pmExchangeInfo"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"disabled": true
+								}
 							]
 						}
 					},

--- a/collections/binance_spot_api_v1.postman_collection.json
+++ b/collections/binance_spot_api_v1.postman_collection.json
@@ -1446,7 +1446,7 @@
 								}
 							]
 						},
-						"description": "- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 3000"
+						"description": "- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 100"
 					},
 					"response": []
 				}],
@@ -6806,6 +6806,68 @@
 							]
 						},
 						"description": "Displays the user's current margin order count usage for all intervals.\n\nWeight(IP): 20"
+					},
+					"response": []
+				},
+				{
+					"name": "Margin Dustlog (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/dribblet?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"dribblet"
+							],
+							"query": [
+								{
+									"key": "startTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "endTime",
+									"value": "",
+									"description": "UTC timestamp in ms",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Query the historical information of user's margin account small-value asset conversion BNB.\n\nWeight(IP): 1"
 					},
 					"response": []
 				}],
@@ -15477,6 +15539,67 @@
 							]
 						},
 						"description": "- Currently supports querying the following business assets：Binance Pay, Binance Card, Binance Gift Card, Stock Token\n\nWeight(IP): 1"
+					},
+					"response": []
+				},
+				{
+					"name": "User Asset (USER_DATA)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v3/asset/getUserAsset?timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v3",
+								"asset",
+								"getUserAsset"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": "BNB",
+									"description": "If asset is blank, then query all positive assets user have.",
+									"disabled": true
+								},
+								{
+									"key": "needBtcValuation",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "UTC timestamp in ms"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}",
+									"description": "Signature"
+								}
+							]
+						},
+						"description": "Get user assets, just for positive data.\n\nWeight(IP): 5"
 					},
 					"response": []
 				},


### PR DESCRIPTION
New endpoints:
- `POST /fapi/v1/multiAssetsMargin` to change Multi-Assets margin mode
- `GET /fapi/v1/multiAssetsMargin` to check Multi-Assets margin mode

New endpoint for Margin:
  - `POST /sapi/v3/asset/getUserAsset` to get user assets.

New endpoint for Wallet:
  - `GET /sapi/v1/margin/dribblet` to query the historical information of user's margin account small-value asset conversion BNB.

Update endpoint for Convert:
  - `GET /sapi/v1/fiat/orders`: Weight changes from IP(3000) to IP(100)
  
New endpoints for Portfolio Margin:
- `GET /fapi/v1/pmExchangeInfo` to get current Portfolio Margin exchange trading rules.
- `GET /dapi/v1/pmExchangeInfo` to get current Portfolio Margin exchange trading rules.