### PR TITLE
Added 'SPOT' to type on Daily Account Snapshot

### DIFF
--- a/collections/binance_spot_api_v1.postman_collection.json
+++ b/collections/binance_spot_api_v1.postman_collection.json
@@ -1,15922 +1,14276 @@
 {
-	"info": {
-		"_postman_id": "9b22864c-c1e4-4537-97ae-a8c00effc5ed",
-		"name": "Binance spot API",
-		"description": "Binance official supported Postman collections.<br/>\n- API documents: https://binance-docs.github.io/apidocs/spot/en/#change-log\n- Telegram: https://t.me/binance_api_english\n- Open Issue at: https://github.com/binance-exchange/binance-api-postman",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-	},
-	"item": [
-		{
-			"name": "BLVT",
-			"item": [
-				{
-					"name": "Get BLVT Info (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/blvt/tokenInfo",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"blvt",
-								"tokenInfo"
-							],
-							"query": [
-								{
-									"key": "tokenName",
-									"value": "",
-									"description": "BTCDOWN, BTCUP",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Subscribe BLVT (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/blvt/subscribe?tokenName=&cost=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"blvt",
-								"subscribe"
-							],
-							"query": [
-								{
-									"key": "tokenName",
-									"value": "",
-									"description": "BTCDOWN, BTCUP"
-								},
-								{
-									"key": "cost",
-									"value": "",
-									"description": "Spot balance"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Subscription Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/blvt/subscribe/record?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"blvt",
-								"subscribe",
-								"record"
-							],
-							"query": [
-								{
-									"key": "tokenName",
-									"value": "",
-									"description": "BTCDOWN, BTCUP",
-									"disabled": true
-								},
-								{
-									"key": "id",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Only the data of the latest 90 days is available\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Redeem BLVT (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/blvt/redeem?tokenName=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"blvt",
-								"redeem"
-							],
-							"query": [
-								{
-									"key": "tokenName",
-									"value": "",
-									"description": "BTCDOWN, BTCUP"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Redemption Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/blvt/redeem/record?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"blvt",
-								"redeem",
-								"record"
-							],
-							"query": [
-								{
-									"key": "tokenName",
-									"value": "",
-									"description": "BTCDOWN, BTCUP",
-									"disabled": true
-								},
-								{
-									"key": "id",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 1000, max 1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Only the data of the latest 90 days is available\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get BLVT User Limit Info (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/blvt/userLimit?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"blvt",
-								"userLimit"
-							],
-							"query": [
-								{
-									"key": "tokenName",
-									"value": "",
-									"description": "BTCDOWN, BTCUP",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": "Binance Leveraged Tokens Endpoints"
-		},
-		{
-			"name": "BSwap",
-			"item": [
-				{
-					"name": "List All Swap Pools (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/pools",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"pools"
-							]
-						},
-						"description": "Get metadata about all swap pools.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get liquidity information of a pool (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/liquidity?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"liquidity"
-							],
-							"query": [
-								{
-									"key": "poolId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get liquidity information and user share of a pool.\n\nWeight(IP):\n- `1` for one pool;\n- `10` when the poolId parameter is omitted;"
-					},
-					"response": []
-				},
-				{
-					"name": "Add Liquidity (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/liquidityAdd?poolId=&asset=BTC&quantity=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"liquidityAdd"
-							],
-							"query": [
-								{
-									"key": "poolId",
-									"value": ""
-								},
-								{
-									"key": "type",
-									"value": "Single",
-									"description": "* `Single` - to add a single token\n* `Combination` - to add dual tokens",
-									"disabled": true
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "quantity",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Add liquidity to a pool.\n\nWeight(UID): 1000 (Additional: 3 times one second)"
-					},
-					"response": []
-				},
-				{
-					"name": "Remove Liquidity (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/liquidityRemove?poolId=&type=SINGLE&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"liquidityRemove"
-							],
-							"query": [
-								{
-									"key": "poolId",
-									"value": ""
-								},
-								{
-									"key": "type",
-									"value": "SINGLE",
-									"description": "* `SINGLE` - for single asset removal\n* `COMBINATION` - for combination of all coins removal"
-								},
-								{
-									"key": "asset",
-									"value": "BNB",
-									"description": "Mandatory for single asset removal",
-									"disabled": true
-								},
-								{
-									"key": "shareAmount",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Remove liquidity from a pool, `type` include `SINGLE` and `COMBINATION`, asset is mandatory for single asset removal\n\nWeight(UID): 1000 (Additional: 3 times one second)"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Liquidity Operation Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/liquidityOps?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"liquidityOps"
-							],
-							"query": [
-								{
-									"key": "operationId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "poolId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "operation",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "100",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get liquidity operation (add/remove) records.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Request Quote (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/quote?quoteAsset=USDT&baseAsset=BUSD&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"quote"
-							],
-							"query": [
-								{
-									"key": "quoteAsset",
-									"value": "USDT"
-								},
-								{
-									"key": "baseAsset",
-									"value": "BUSD"
-								},
-								{
-									"key": "quoteQty",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Request a quote for swap quote asset (selling asset) for base asset (buying asset), essentially price/exchange rates.\n\nquoteQty is quantity of quote asset (to sell).\n\nPlease be noted the quote is for reference only, the actual price will change as the liquidity changes, it's recommended to swap immediate after request a quote for slippage prevention.\n\nWeight(UID): 150"
-					},
-					"response": []
-				},
-				{
-					"name": "Swap (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/swap?quoteAsset=USDT&baseAsset=BUSD&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"swap"
-							],
-							"query": [
-								{
-									"key": "quoteAsset",
-									"value": "USDT"
-								},
-								{
-									"key": "baseAsset",
-									"value": "BUSD"
-								},
-								{
-									"key": "quoteQty",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Swap `quoteAsset` for `baseAsset`.\n\nWeight(UID): 1000 (Additional: 3 times one second)"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Swap History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/swap?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"swap"
-							],
-							"query": [
-								{
-									"key": "swapId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "status",
-									"value": "",
-									"description": "* `0` - pending for swap\n* `1` - success\n* `2` - failed",
-									"disabled": true
-								},
-								{
-									"key": "quoteAsset",
-									"value": "USDT",
-									"disabled": true
-								},
-								{
-									"key": "baseAsset",
-									"value": "BUSD",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 3, max 100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get swap history.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Pool Configure (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/poolConfigure?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"poolConfigure"
-							],
-							"query": [
-								{
-									"key": "poolId",
-									"value": "2",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 150"
-					},
-					"response": []
-				},
-				{
-					"name": "Add Liquidity Preview (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/addLiquidityPreview?poolId=2&type=SINGLE&quoteAsset=USDT&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"addLiquidityPreview"
-							],
-							"query": [
-								{
-									"key": "poolId",
-									"value": "2"
-								},
-								{
-									"key": "type",
-									"value": "SINGLE",
-									"description": "* `SINGLE` - for adding a single token\n* `COMBINATION` - for adding dual tokens"
-								},
-								{
-									"key": "quoteAsset",
-									"value": "USDT"
-								},
-								{
-									"key": "quoteQty",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Calculate expected share amount for adding liquidity in single or dual token.\n\nWeight(IP): 150"
-					},
-					"response": []
-				},
-				{
-					"name": "Remove Liquidity Preview (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/removeLiquidityPreview?poolId=2&type=SINGLE&quoteAsset=USDT&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"removeLiquidityPreview"
-							],
-							"query": [
-								{
-									"key": "poolId",
-									"value": "2"
-								},
-								{
-									"key": "type",
-									"value": "SINGLE",
-									"description": "* `SINGLE` - remove and obtain a single token\n* `COMBINATION` - remove and obtain dual token"
-								},
-								{
-									"key": "quoteAsset",
-									"value": "USDT"
-								},
-								{
-									"key": "shareAmount",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Calculate the expected asset amount of single token redemption or dual token redemption.\n\nWeight(IP): 150"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Unclaimed Rewards Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/unclaimedRewards?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"unclaimedRewards"
-							],
-							"query": [
-								{
-									"key": "type",
-									"value": "0",
-									"description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get unclaimed rewards record.\n \nWeight(UID): 1000"
-					},
-					"response": []
-				},
-				{
-					"name": "Claim Rewards (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/claimRewards?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"claimRewards"
-							],
-							"query": [
-								{
-									"key": "type",
-									"value": "0",
-									"description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Claim swap rewards or liquidity rewards\n \nWeight(UID): 1000"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Claimed History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bswap/claimedHistory?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bswap",
-								"claimedHistory"
-							],
-							"query": [
-								{
-									"key": "poolId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "assetRewards",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "type",
-									"value": "0",
-									"description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "Default 3, max 100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get history of claimed rewards.\n \nWeight(UID): 1000"
-					},
-					"response": []
-				}],
-			"description": "Binance Swap Endpoints"
-		},
-		{
-			"name": "C2C",
-			"item": [
-				{
-					"name": "Get C2C Trade History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/c2c/orderMatch/listUserOrderHistory?tradeType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"c2c",
-								"orderMatch",
-								"listUserOrderHistory"
-							],
-							"query": [
-								{
-									"key": "tradeType",
-									"value": "",
-									"description": "BUY, SELL"
-								},
-								{
-									"key": "startTimestamp",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTimestamp",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "rows",
-									"value": "",
-									"description": "default 100, max 100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If startTimestamp and endTimestamp are not sent, the recent 30-day data will be returned.\n- The max interval between startTimestamp and endTimestamp is 30 days.\n\nWeight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": "Consumer-To-Consumer Endpoints"
-		},
-		{
-			"name": "Convert",
-			"item": [
-				{
-					"name": "Get Convert Trade History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/convert/tradeFlow?startTime=&endTime=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"convert",
-								"tradeFlow"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "limit",
-									"value": "100",
-									"description": "default 100, max 1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 100"
-					},
-					"response": []
-				}],
-			"description": "Convert Endpoints"
-		},
-		{
-			"name": "Crypto Loans",
-			"item": [
-				{
-					"name": "Get Crypto Loans Income History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/loan/income?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"loan",
-								"income"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "All types will be returned by default.\n* `borrowIn`\n* `collateralSpent`\n* `repayAmount`\n* `collateralReturn` - Collateral return after repayment\n* `addCollateral`\n* `removeCollateral`\n* `collateralReturnAfterLiquidation`",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "20",
-									"description": "default 20, max 100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If startTime and endTime are not sent, the recent 7-day data will be returned.\n- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 6000"
-					},
-					"response": []
-				}],
-			"description": "Crypto Loans Endpoints"
-		},
-		{
-			"name": "Fiat",
-			"item": [
-				{
-					"name": "Get Fiat Deposit/Withdraw History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/fiat/orders?transactionType=0&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"fiat",
-								"orders"
-							],
-							"query": [
-								{
-									"key": "transactionType",
-									"value": "0",
-									"description": "* `0` - deposit\n* `1` - withdraw"
-								},
-								{
-									"key": "beginTime",
-									"value": "1626144956000",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "rows",
-									"value": "300",
-									"description": "Default 100, max 500",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(UID): 90000"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Fiat Payments History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/fiat/payments?transactionType=0&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"fiat",
-								"payments"
-							],
-							"query": [
-								{
-									"key": "transactionType",
-									"value": "0",
-									"description": "* `0` - deposit\n* `1` - withdraw"
-								},
-								{
-									"key": "beginTime",
-									"value": "1626144956000",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "rows",
-									"value": "300",
-									"description": "Default 100, max 500",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": "Fiat Endpoints"
-		},
-		{
-			"name": "Futures",
-			"item": [
-				{
-					"name": "New Future Account Transfer (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/transfer?asset=&amount=&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "",
-									"description": "The asset being transferred, e.g., USDT"
-								},
-								{
-									"key": "amount",
-									"value": "",
-									"description": "The amount to be transferred"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "1: transfer from spot account to USDT-Ⓜ futures account. 2: transfer from USDT-Ⓜ futures account to spot account. 3: transfer from spot account to COIN-Ⓜ futures account. 4: transfer from COIN-Ⓜ futures account to spot account."
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Execute transfer between spot account and futures account.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Future Account Transaction History List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/transfer?asset=&startTime=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": ""
-								},
-								{
-									"key": "startTime",
-									"value": ""
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "",
-									"description": "Currently querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Borrow For Cross-Collateral (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/borrow?coin=&collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"borrow"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "collateralAmount",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Borrow asset for Cross-Collateral."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Borrow History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/borrow/history?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"borrow",
-								"history"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 500, max 1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Cross-Collateral Borrow History."
-					},
-					"response": []
-				},
-				{
-					"name": "Repay For Cross-Collateral (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/repay?coin=&collateralCoin=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"repay"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": ""
-								},
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Repay Transaction."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Repayment History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/repay/history?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"repay",
-								"history"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 500, max 1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Cross-Collateral Repayment History."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Wallet (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/wallet?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"wallet"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Cross-Collateral Wallet."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Wallet V2 (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/futures/loan/wallet?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"futures",
-								"loan",
-								"wallet"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Cross-Collateral Wallet V2."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Information (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/configs?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"configs"
-							],
-							"query": [
-								{
-									"key": "collateralCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Cross-Collateral Information."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Information V2 (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/futures/loan/configs?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"futures",
-								"loan",
-								"configs"
-							],
-							"query": [
-								{
-									"key": "loanCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "collateralCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Cross-Collateral Information V2."
-					},
-					"response": []
-				},
-				{
-					"name": "Calculate Rate After Adjust Cross-Collateral LTV (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/calcAdjustLevel?collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"calcAdjustLevel"
-							],
-							"query": [
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "direction",
-									"value": "",
-									"description": "\"ADDITIONAL\", \"REDUCED\""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Calculate Collateral Rate after adjust Cross-Collateral LTV."
-					},
-					"response": []
-				},
-				{
-					"name": "Calculate Rate After Adjust Cross-Collateral LTV V2 (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/futures/loan/calcAdjustLevel?loanCoin=&collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"futures",
-								"loan",
-								"calcAdjustLevel"
-							],
-							"query": [
-								{
-									"key": "loanCoin",
-									"value": ""
-								},
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "direction",
-									"value": "",
-									"description": "\"ADDITIONAL\", \"REDUCED\""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Calculate Collateral Rate after adjust Cross-Collateral LTV V2."
-					},
-					"response": []
-				},
-				{
-					"name": "Get Max Amount for Adjust Cross-Collateral LTV (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/calcMaxAdjustAmount?collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"calcMaxAdjustAmount"
-							],
-							"query": [
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Max Amount for Adjust Cross-Collateral LTV."
-					},
-					"response": []
-				},
-				{
-					"name": "Get Max Amount for Adjust Cross-Collateral LTV V2 (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/futures/loan/calcMaxAdjustAmount?loanCoin=&collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"futures",
-								"loan",
-								"calcMaxAdjustAmount"
-							],
-							"query": [
-								{
-									"key": "loanCoin",
-									"value": ""
-								},
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Max Amount for Adjust Cross-Collateral LTV V2."
-					},
-					"response": []
-				},
-				{
-					"name": "Adjust Cross-Collateral LTV (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/adjustCollateral?collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"adjustCollateral"
-							],
-							"query": [
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "direction",
-									"value": "",
-									"description": "\"ADDITIONAL\", \"REDUCED\""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Adjust Cross-Collateral LTV."
-					},
-					"response": []
-				},
-				{
-					"name": "Adjust Cross-Collateral LTV V2 (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/futures/loan/adjustCollateral?loanCoin=&collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"futures",
-								"loan",
-								"adjustCollateral"
-							],
-							"query": [
-								{
-									"key": "loanCoin",
-									"value": ""
-								},
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "direction",
-									"value": "",
-									"description": "\"ADDITIONAL\", \"REDUCED\""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Adjust Cross-Collateral LTV V2."
-					},
-					"response": []
-				},
-				{
-					"name": "Adjust Cross-Collateral LTV History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/adjustCollateral/history?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"adjustCollateral",
-								"history"
-							],
-							"query": [
-								{
-									"key": "loanCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "collateralCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 500, max 1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Adjust Cross-Collateral LTV History."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Liquidation History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/liquidationHistory?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"liquidationHistory"
-							],
-							"query": [
-								{
-									"key": "loanCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "collateralCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "default 500, max 1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get Cross-Collateral Liquidation History."
-					},
-					"response": []
-				},
-				{
-					"name": "Check Collateral Repay Limit (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/collateralRepayLimit?coin=&collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"collateralRepayLimit"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": ""
-								},
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Check the maximum and minimum limit when repay with collateral."
-					},
-					"response": []
-				},
-				{
-					"name": "Get Collateral Repay Quote (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/collateralRepay?coin=&collateralCoin=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"collateralRepay"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": ""
-								},
-								{
-									"key": "collateralCoin",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": "",
-									"description": "repay amount"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds."
-					},
-					"response": []
-				},
-				{
-					"name": "Repay with Collateral (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/collateralRepay?quoteId=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"collateralRepay"
-							],
-							"query": [
-								{
-									"key": "quoteId",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Repay with collateral. Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds."
-					},
-					"response": []
-				},
-				{
-					"name": "Collateral Repayment Result (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/collateralRepayResult?quoteId=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"collateralRepayResult"
-							],
-							"query": [
-								{
-									"key": "quoteId",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Check collateral repayment result."
-					},
-					"response": []
-				},
-				{
-					"name": "Cross-Collateral Interest History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/futures/loan/interestHistory?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"futures",
-								"loan",
-								"interestHistory"
-							],
-							"query": [
-								{
-									"key": "collateralCoin",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "",
-									"description": "Currently querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "Default:500 Max:1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": ""
-					},
-					"response": []
-				}],
-			"description": ""
-		},
-		{
-			"name": "Futures Algo",
-			"item": [
-				{
-					"name": "Volume Participation New Order (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/algo/futures/newOrderVp?symbol=&side=SELL&quantity=&urgency=LOW&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"algo",
-								"futures",
-								"newOrderVp"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Trading symbol eg. BTCUSDT"
-								},
-								{
-									"key": "side",
-									"value": "SELL",
-									"description": "Trading side ( BUY or SELL )"
-								},
-								{
-									"key": "positionSide",
-									"value": "",
-									"description": "Default BOTH for One-way Mode ; LONG or SHORT for Hedge Mode. It must be sent in Hedge Mode.",
-									"disabled": true
-								},
-								{
-									"key": "quantity",
-									"value": "",
-									"description": "Quantity of base asset; The notional (quantity * mark price(base asset)) must be more than the equivalent of 10,000 USDT and less than the equivalent of 1,000,000 USDT."
-								},
-								{
-									"key": "urgency",
-									"value": "LOW",
-									"description": "Represent the relative speed of the current execution; ENUM: LOW, MEDIUM, HIGH."
-								},
-								{
-									"key": "clientAlgoId",
-									"value": "",
-									"description": "A unique id among Algo orders (length should be 32 characters)， If it is not sent, we will give default value.",
-									"disabled": true
-								},
-								{
-									"key": "reduceOnly",
-									"value": "",
-									"description": "\"true\" or \"false\". Default \"false\"; Cannot be sent in Hedge Mode; Cannot be sent when you open a position.",
-									"disabled": true
-								},
-								{
-									"key": "limitPrice",
-									"value": "",
-									"description": "Limit price of the order; If it is not sent, will place order by market price by default.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Send in a VP new order. Only support on USDⓈ-M Contracts.\n\nWeight(IP): 3000\n\n- Max open orders allowed: 10 orders.\n- Leverage of symbols and position mode will be the same as your futures account settings. You can set up through the trading page or fapi.\n- Receiving \"success\": true does not mean that your order will be executed. Please use the query order endpoints（GET sapi/v1/algo/futures/openOrders or GET sapi/v1/algo/futures/historicalOrders） to check the order status. For example: Your futures balance is insufficient, or open position with reduce only or position side is inconsistent with your own setting. In these cases you will receive \"success\": true, but the order status will be expired after we check it."
-					},
-					"response": []
-				},
-				{
-					"name": "Time-Weighted Average Price New Order (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/algo/futures/newOrderTwap?symbol=&side=&quantity=&duration=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"algo",
-								"futures",
-								"newOrderTwap"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Trading symbol eg. BTCUSDT"
-								},
-								{
-									"key": "side",
-									"value": "",
-									"description": "Trading side ( BUY or SELL )"
-								},
-								{
-									"key": "positionSide",
-									"value": "",
-									"description": "Default BOTH for One-way Mode ; LONG or SHORT for Hedge Mode. It must be sent in Hedge Mode.",
-									"disabled": true
-								},
-								{
-									"key": "quantity",
-									"value": "",
-									"description": "Quantity of base asset; The notional (quantity * mark price(base asset)) must be more than the equivalent of 10,000 USDT and less than the equivalent of 1,000,000 USDT"
-								},
-								{
-									"key": "duration",
-									"value": "",
-									"description": "Duration for TWAP orders in seconds. [300, 86400];Less than 5min => defaults to 5 min; Greater than 24h => defaults to 24h"
-								},
-								{
-									"key": "clientAlgoId",
-									"value": "",
-									"description": "A unique id among Algo orders (length should be 32 characters)， If it is not sent, we will give default value",
-									"disabled": true
-								},
-								{
-									"key": "reduceOnly",
-									"value": "",
-									"description": "`true` or `false`. Default `false`; Cannot be sent in Hedge Mode; Cannot be sent when you open a position",
-									"disabled": true
-								},
-								{
-									"key": "limitPrice",
-									"value": "",
-									"description": "Limit price of the order; If it is not sent, will place order by market price by default",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Send in a Twap new order. Only support on USDⓈ-M Contracts.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel Algo Order (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/algo/futures/order?algoId=14511&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"algo",
-								"futures",
-								"order"
-							],
-							"query": [
-								{
-									"key": "algoId",
-									"value": "14511"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Cancel an active order.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Current Algo Open Orders (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/algo/futures/openOrders?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"algo",
-								"futures",
-								"openOrders"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Historical Algo Orders (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/algo/futures/historicalOrders?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"algo",
-								"futures",
-								"historicalOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Trading symbol eg. BTCUSDT",
-									"disabled": true
-								},
-								{
-									"key": "side",
-									"value": "",
-									"description": "BUY or SELL",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "Default is 1",
-									"disabled": true
-								},
-								{
-									"key": "pageSize",
-									"value": "",
-									"description": "MIN 1, MAX 100; Default 100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub Orders (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/algo/futures/subOrders?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"algo",
-								"futures",
-								"subOrders"
-							],
-							"query": [
-								{
-									"key": "algoId",
-									"value": "13723",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "",
-									"description": "Default is 1",
-									"disabled": true
-								},
-								{
-									"key": "pageSize",
-									"value": "",
-									"description": "MIN 1, MAX 100; Default 100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get respective sub orders for a specified algoId\n\nWeight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": ""
-		},
-		{
-			"name": "Gift Card",
-			"item": [
-				{
-					"name": "Create a Binance Code (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/giftcard/createCode?token=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"giftcard",
-								"createCode"
-							],
-							"query": [
-								{
-									"key": "token",
-									"value": "",
-									"description": "The coin type contained in the Binance Code"
-								},
-								{
-									"key": "amount",
-									"value": "",
-									"description": "The amount of the coin"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "This API is for creating a Binance Code. To get started with, please make sure:\n\n- You have a Binance account\n- You have passed kyc\n- You have a sufﬁcient balance in your Binance funding wallet\n- You need Enable Withdrawals for the API Key which requests this endpoint.\n\nDaily creation volume: 2 BTC / 24H Daily creation times: 200 Codes / 24H\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Redeem a Binance Code (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/giftcard/redeemCode?code=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"giftcard",
-								"redeemCode"
-							],
-							"query": [
-								{
-									"key": "code",
-									"value": "",
-									"description": "Binance Code"
-								},
-								{
-									"key": "externalUid",
-									"value": "",
-									"description": "Each external unique ID represents a unique user on the partner platform. The function helps you to identify the redemption behavior of different users, such as redemption frequency and amount. It also helps risk and limit control of a single account, such as daily limit on redemption volume, frequency, and incorrect number of entries. This will also prevent a single user account reach the partner's daily redemption limits. We strongly recommend you to use this feature and transfer us the User ID of your users if you have different users redeeming Binance codes on your platform. To protect user data privacy, you may choose to transfer the user id in any desired format (max. 400 characters).",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "This API is for redeeming the Binance Code. Once redeemed, the coins will be deposited in your funding wallet.\n\nPlease note that if you enter the wrong code 5 times within 24 hours, you will no longer be able to redeem any Binance Code that day.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Verify a Binance Code (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/giftcard/verify?referenceNo=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"giftcard",
-								"verify"
-							],
-							"query": [
-								{
-									"key": "referenceNo",
-									"value": "",
-									"description": "reference number"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "This API is for verifying whether the Binance Code is valid or not by entering Binance Code or reference number.\n\nPlease note that if you enter the wrong binance code 5 times within an hour, you will no longer be able to verify any binance code for that hour.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Fetch RSA Public Key (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/giftcard/cryptography/rsa-public-key?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"giftcard",
-								"cryptography",
-								"rsa-public-key"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "This API is for fetching the RSA Public Key.\nThis RSA Public key will be used to encrypt the card code.\nPlease note that the RSA Public key fetched is valid only for the current day.\n\nWeight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": "Gift Card Endpoints"
-		},
-		{
-			"name": "Margin",
-			"item": [
-				{
-					"name": "Cross Margin Account Transfer (MARGIN)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/transfer?asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "* `1` - transfer from main account to margin account\n* `2` - transfer from margin account to main account"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Execute transfer between spot account and cross margin account.\n\nWeight(IP): 600"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Cross Margin Transfer History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/transfer?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "Transfer Type",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "archived",
-									"value": "",
-									"description": "Default: false. Set to true for archived data from 6 months ago",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Response in descending order\n- Returns data for last 7 days by default\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account Borrow (MARGIN)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/loan?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"loan"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Apply for a loan.\n\n- If \"isIsolated\" = \"TRUE\", \"symbol\" must be sent\n- \"isIsolated\" = \"FALSE\" for crossed margin loan\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Loan Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/loan?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"loan"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"description": "Isolated symbol",
-									"disabled": true
-								},
-								{
-									"key": "txId",
-									"value": "123456789",
-									"description": "the tranId in  `POST /sapi/v1/margin/loan`",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "archived",
-									"value": "",
-									"description": "Default: false. Set to true for archived data from 6 months ago",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- `txId` or `startTime` must be sent. `txId` takes precedence.\n- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account Repay (MARGIN)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/repay?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"repay"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Repay loan for margin account.\n\n- If \"isIsolated\" = \"TRUE\", \"symbol\" must be sent\n- \"isIsolated\" = \"FALSE\" for crossed margin repay\n\nWeight(IP): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Repay Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/repay?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"repay"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"description": "Isolated symbol",
-									"disabled": true
-								},
-								{
-									"key": "txId",
-									"value": "2970933056",
-									"description": "the tranId in  `POST /sapi/v1/margin/repay`",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "archived",
-									"value": "",
-									"description": "Default: false. Set to true for archived data from 6 months ago",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- `txId` or `startTime` must be sent. `txId` takes precedence.\n- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Asset (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/asset?asset=BTC",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"asset"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Cross Margin Pair (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/pair?symbol=BNBUSDT",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"pair"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Get All Margin Assets (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/allAssets",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"allAssets"
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get All Cross Margin Pairs (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/allPairs",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"allPairs"
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin PriceIndex (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/priceIndex?symbol=BNBUSDT",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"priceIndex"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's Order (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"description": "Order id",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"description": "Order id from client",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Either `orderId` or `origClientOrderId` must be sent.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account New Order (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "side",
-									"value": "SELL"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "Order type"
-								},
-								{
-									"key": "quantity",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "quoteOrderQty",
-									"value": "",
-									"description": "Quote quantity",
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": "",
-									"description": "Order price",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": "20.01",
-									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "icebergQty",
-									"value": "",
-									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": "",
-									"description": "Set the response JSON.",
-									"disabled": true
-								},
-								{
-									"key": "sideEffectType",
-									"value": "",
-									"description": "Default `NO_SIDE_EFFECT`",
-									"disabled": true
-								},
-								{
-									"key": "timeInForce",
-									"value": "",
-									"description": "Order time in force",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Post a new order for margin account.\n\nWeight(UID): 6"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account Cancel Order (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"description": "Order id",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"description": "Order id from client",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Cancel an active order for margin account.\n\nEither `orderId` or `origClientOrderId` must be sent.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Interest History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/interestHistory?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"interestHistory"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"description": "Isolated symbol",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "archived",
-									"value": "",
-									"description": "Default: false. Set to true for archived data from 6 months ago",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n- `type` in response has 4 enums:\n  - `PERIODIC` interest charged per hour\n  - `ON_BORROW` first interest charged on borrow\n  - `PERIODIC_CONVERTED` interest charged per hour converted into BNB\n  - `ON_BORROW_CONVERTED` first interest charged on borrow converted into BNB\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Force Liquidation Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/forceLiquidationRec?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"forceLiquidationRec"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"description": "Isolated symbol",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Response in descending order\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Cross Margin Account Details (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/account?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"account"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's Open Orders (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/openOrders?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"openOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If the `symbol` is not sent, orders for all symbols will be returned in an array.\n- When all symbols are returned, the number of requests counted against the rate limiter is equal to the number of symbols currently trading on the exchange\n- If isIsolated =\"TRUE\", symbol must be sent.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account Cancel all Open Orders on a Symbol (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/openOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"openOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Cancels all active orders on a symbol for margin account.\n- This includes OCO orders.\n\nWeight(IP): 1\n"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's All Orders (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/allOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"allOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"description": "Order id",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If `orderId` is set, it will get orders >= that orderId. Otherwise most recent orders are returned.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 200\n\nRequest Limit: 60 times/min per IP"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account New OCO (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/order/oco?symbol=BNBUSDT&side=SELL&quantity=&price=&stopPrice=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"order",
-								"oco"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "listClientOrderId",
-									"value": "",
-									"description": "A unique Id for the entire orderList",
-									"disabled": true
-								},
-								{
-									"key": "side",
-									"value": "SELL"
-								},
-								{
-									"key": "quantity",
-									"value": ""
-								},
-								{
-									"key": "limitClientOrderId",
-									"value": "",
-									"description": "A unique Id for the limit order",
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": "",
-									"description": "Order price"
-								},
-								{
-									"key": "limitIcebergQty",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "stopClientOrderId",
-									"value": "",
-									"description": "A unique Id for the stop loss/stop loss limit leg",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": ""
-								},
-								{
-									"key": "stopLimitPrice",
-									"value": "",
-									"description": "If provided, stopLimitTimeInForce is required.",
-									"disabled": true
-								},
-								{
-									"key": "stopIcebergQty",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "stopLimitTimeInForce",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": "",
-									"description": "Set the response JSON.",
-									"disabled": true
-								},
-								{
-									"key": "sideEffectType",
-									"value": "",
-									"description": "Default `NO_SIDE_EFFECT`",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Send in a new OCO for a margin account\n\n- Price Restrictions:\n  - SELL: Limit Price > Last Price > Stop Price\n  - BUY: Limit Price < Last Price < Stop Price\n- Quantity Restrictions:\n  - Both legs must have the same quantity\n  - ICEBERG quantities however do not have to be the same.\n- Order Rate Limit\n  - OCO counts as 2 orders against the order rate limit.\n\nWeight(UID): 6"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/orderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"orderList"
-							],
-							"query": [
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Mandatory for isolated margin, not supported for cross margin",
-									"disabled": true
-								},
-								{
-									"key": "orderListId",
-									"value": "",
-									"description": "Order list id",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"description": "Order id from client",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Retrieves a specific OCO based on provided optional parameters\n\n- Either `orderListId` or `origClientOrderId` must be provided\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Account Cancel OCO (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/orderList?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"orderList"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "orderListId",
-									"value": "",
-									"description": "Order list id",
-									"disabled": true
-								},
-								{
-									"key": "listClientOrderId",
-									"value": "",
-									"description": "A unique Id for the entire orderList",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Cancel an entire Order List for a margin account\n\n- Canceling an individual leg will cancel the entire OCO\n- Either `orderListId` or `listClientOrderId` must be provided\n\nWeight(UID): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's all OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/allOrderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"allOrderList"
-							],
-							"query": [
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Mandatory for isolated margin, not supported for cross margin",
-									"disabled": true
-								},
-								{
-									"key": "fromId",
-									"value": "",
-									"description": "If supplied, neither `startTime` or `endTime` can be provided",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "Default Value: 500; Max Value: 1000",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Retrieves all OCO for a specific margin account based on provided optional parameters\n\nWeight(IP): 200"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's Open OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/openOrderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"openOrderList"
-							],
-							"query": [
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Mandatory for isolated margin, not supported for cross margin",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Account's Trade List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/myTrades?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"myTrades"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "fromId",
-									"value": "",
-									"description": "Trade id to fetch from. Default gets most recent trades.",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If `fromId` is set, it will get orders >= that `fromId`. Otherwise most recent trades are returned.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Max Borrow (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/maxBorrowable?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"maxBorrowable"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"description": "Isolated symbol",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If `isolatedSymbol` is not sent, crossed margin data will be sent.\n- `borrowLimit` is also available from https://www.binance.com/en/margin-fee\n\nWeight(IP): 50"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Max Transfer-Out Amount (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/maxTransferable?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"maxTransferable"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "isolatedSymbol",
-									"value": "",
-									"description": "Isolated symbol",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If `isolatedSymbol` is not sent, crossed margin data will be sent.\n\nWeight(IP): 50"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Isolated Margin Transfer History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/transfer?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "transFrom",
-									"value": "SPOT",
-									"disabled": true
-								},
-								{
-									"key": "transTo",
-									"value": "ISOLATED_MARGIN",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "archived",
-									"value": "",
-									"description": "Default: false. Set to true for archived data from 6 months ago",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Isolated Margin Account Transfer (MARGIN)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/transfer?asset=BTC&symbol=BNBUSDT&transFrom=SPOT&transTo=ISOLATED_MARGIN&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "transFrom",
-									"value": "SPOT"
-								},
-								{
-									"key": "transTo",
-									"value": "ISOLATED_MARGIN"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(UID): 600"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Isolated Margin Account Info (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/account?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"account"
-							],
-							"query": [
-								{
-									"key": "symbols",
-									"value": "BTCUSDT,BNBUSDT,ADAUSDT",
-									"description": "Max 5 symbols can be sent; separated by ','",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If \"symbols\" is not sent, all isolated assets will be returned.\n- If \"symbols\" is sent, only the isolated assets of the sent symbols will be returned.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Disable Isolated Margin Account (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"account"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Disable isolated margin account for a specific symbol. Each trading pair can only be deactivated once every 24 hours .\n\nWeight(UID): 300"
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Isolated Margin Account (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"account"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Enable isolated margin account for a specific symbol.\n\nWeight(UID): 300"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Enabled Isolated Margin Account Limit (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/accountLimit?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"accountLimit"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Query enabled isolated margin account limit.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Isolated Margin Symbol (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/pair?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"pair"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Get All Isolated Margin Symbol (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolated/allPairs?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolated",
-								"allPairs"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Toggle BNB Burn On Spot Trade And Margin Interest (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bnbBurn?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bnbBurn"
-							],
-							"query": [
-								{
-									"key": "spotBNBBurn",
-									"value": "true",
-									"description": "Determines whether to use BNB to pay for trading fees on SPOT",
-									"disabled": true
-								},
-								{
-									"key": "interestBNBBurn",
-									"value": "false",
-									"description": "Determines whether to use BNB to pay for margin loan's interest",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- \"spotBNBBurn\" and \"interestBNBBurn\" should be sent at least one.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get BNB Burn Status (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/bnbBurn?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"bnbBurn"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Margin Interest Rate History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/interestRateHistory?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"interestRateHistory"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "vipLevel",
-									"value": "",
-									"description": "Defaults to user's vip level",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "The max interval between startTime and endTime is 30 days.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Cross Margin Fee Data (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/crossMarginData?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"crossMarginData"
-							],
-							"query": [
-								{
-									"key": "vipLevel",
-									"value": "",
-									"description": "Defaults to user's vip level",
-									"disabled": true
-								},
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get cross margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee\n\nWeight(IP): 1 when coin is specified; 5 when the coin parameter is omitted"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Isolated Margin Fee Data (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolatedMarginData?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolatedMarginData"
-							],
-							"query": [
-								{
-									"key": "vipLevel",
-									"value": "",
-									"description": "Defaults to user's vip level",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get isolated margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee\n\nWeight(IP): 1 when a single is specified; 10 when the symbol parameter is omitted"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Isolated Margin Tier Data (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/isolatedMarginTier?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"isolatedMarginTier"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "tier",
-									"value": "1",
-									"description": "All margin tier data will be returned if tier is omitted",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get isolated margin tier data collection with any tier as https://www.binance.com/en/margin-data\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Current Margin Order Count Usage (TRADE)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/rateLimit/order?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"rateLimit",
-								"order"
-							],
-							"query": [
-								{
-									"key": "isIsolated",
-									"value": "",
-									"description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "isolated symbol, mandatory for isolated margin",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Displays the user's current margin order count usage for all intervals.\n\nWeight(IP): 20"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Dustlog (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/margin/dribblet?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"margin",
-								"dribblet"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Query the historical information of user's margin account small-value asset conversion BNB.\n\nWeight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": "Margin Account/Trade"
-		},
-		{
-			"name": "Market",
-			"item": [
-				{
-					"name": "Test Connectivity",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/ping",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"ping"
-							]
-						},
-						"description": "Test connectivity to the Rest API.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Check Server Time",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/time",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"time"
-							]
-						},
-						"description": "Test connectivity to the Rest API and get the current server time.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Exchange Information",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/exchangeInfo",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"exchangeInfo"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "symbols",
-									"value": "[\"BTCUSDT\",\"BNBBTC\"]",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Current exchange trading rules and symbol information\n\n- If any symbol provided in either symbol or symbols do not exist, the endpoint will throw an error.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Order Book",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/depth?symbol=BNBUSDT",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"depth"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "limit",
-									"value": "100",
-									"description": "If limit > 5000, then the response will truncate to 5000",
-									"disabled": true
-								}
-							]
-						},
-						"description": "| Limit               | Weight(IP)  |\n|---------------------|-------------|\n| 1-100               | 1           |\n| 101-500             | 5           |\n| 501-1000            | 10          |\n| 1001-5000           | 50          |"
-					},
-					"response": []
-				},
-				{
-					"name": "Recent Trades List",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/trades?symbol=BNBUSDT",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"trades"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Get recent trades.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Old Trade Lookup (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/historicalTrades?symbol=BNBUSDT",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"historicalTrades"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "fromId",
-									"value": "",
-									"description": "Trade id to fetch from. Default gets most recent trades.",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Get older market trades.\n\nWeight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Compressed/Aggregate Trades List",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/aggTrades?symbol=BNBUSDT",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"aggTrades"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "fromId",
-									"value": "",
-									"description": "Trade id to fetch from. Default gets most recent trades.",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Get compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.\n- If `startTime` and `endTime` are sent, time between startTime and endTime must be less than 1 hour.\n- If `fromId`, `startTime`, and `endTime` are not sent, the most recent aggregate trades will be returned.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Kline/Candlestick Data",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/klines?symbol=BNBUSDT&interval=",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"klines"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "interval",
-									"value": "",
-									"description": "kline intervals"
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Kline/candlestick bars for a symbol.\nKlines are uniquely identified by their open time.\n\n- If `startTime` and `endTime` are not sent, the most recent klines are returned.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Current Average Price",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/avgPrice?symbol=BNBUSDT",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"avgPrice"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								}
-							]
-						},
-						"description": "Current average price for a symbol.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "24hr Ticker Price Change Statistics",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/ticker/24hr",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"ticker",
-								"24hr"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "symbols",
-									"value": "",
-									"disabled": true
-								}
-							]
-						},
-						"description": "24 hour rolling window price change statistics. Careful when accessing this with no symbol.\n\n- If the symbol is not sent, tickers for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `40` when the symbol parameter is omitted;"
-					},
-					"response": []
-				},
-				{
-					"name": "Symbol Price Ticker",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/ticker/price",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"ticker",
-								"price"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "symbols",
-									"value": "",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Latest price for a symbol or symbols.\n\n- If the symbol is not sent, prices for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `2` when the symbol parameter is omitted;"
-					},
-					"response": []
-				},
-				{
-					"name": "Symbol Order Book Ticker",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/ticker/bookTicker",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"ticker",
-								"bookTicker"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "symbols",
-									"value": "",
-									"disabled": true
-								}
-							]
-						},
-						"description": "Best price/qty on the order book for a symbol or symbols.\n\n- If the symbol is not sent, bookTickers for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `2` when the symbol parameter is omitted;"
-					},
-					"response": []
-				},
-				{
-					"name": "Rolling window price change statistics",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/ticker",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"ticker"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "symbols",
-									"value": "",
-									"description": "Either symbol or symbols must be provided\nExamples of accepted format for the symbols parameter: [\"BTCUSDT\",\"BNBUSDT\"] or %5B%22BTCUSDT%22,%22BNBUSDT%22%5D.\n\nThe maximum number of symbols allowed in a request is 100.",
-									"disabled": true
-								},
-								{
-									"key": "windowSize",
-									"value": "",
-									"description": "Defaults to 1d if no parameter provided.\nSupported windowSize values:\n1m,2m....59m for minutes\n1h, 2h....23h - for hours\n1d...7d - for days.\n\nUnits cannot be combined (e.g. 1d2h is not allowed)",
-									"disabled": true
-								}
-							]
-						},
-						"description": "The window used to compute statistics is typically slightly wider than requested windowSize.\n\nopenTime for /api/v3/ticker always starts on a minute, while the closeTime is the current time of the request. As such, the effective window might be up to 1 minute wider than requested.\n\nE.g. If the closeTime is 1641287867099 (January 04, 2022 09:17:47:099 UTC) , and the windowSize is 1d. the openTime will be: 1641201420000 (January 3, 2022, 09:17:00 UTC)\n\nWeight(IP): 2 for each requested symbol regardless of windowSize.\n\nThe weight for this request will cap at 100 once the number of symbols in the request is more than 50."
-					},
-					"response": []
-				}],
-			"description": "Market Data"
-		},
-		{
-			"name": "Mining",
-			"item": [
-				{
-					"name": "Acquiring Algorithm (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/pub/algoList",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"pub",
-								"algoList"
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Acquiring CoinName (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/pub/coinList",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"pub",
-								"coinList"
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Request for Detail Miner List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/worker/detail?algo=&userName=&workerName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"worker",
-								"detail"
-							],
-							"query": [
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "workerName",
-									"value": "",
-									"description": "Miner’s name"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Request for Miner List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/worker/list?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"worker",
-								"list"
-							],
-							"query": [
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "pageIndex",
-									"value": "",
-									"description": "Page number, default is first page, start form 1",
-									"disabled": true
-								},
-								{
-									"key": "sort",
-									"value": "",
-									"description": "sort sequence（default=0）0 positive sequence, 1 negative sequence",
-									"disabled": true
-								},
-								{
-									"key": "sortColumn",
-									"value": "",
-									"description": "Sort by( default 1): 1: miner name, 2: real-time computing power, 3: daily average computing power, 4: real-time rejection rate, 5: last submission time",
-									"disabled": true
-								},
-								{
-									"key": "workerStatus",
-									"value": "",
-									"description": "miners status（default=0）0 all, 1 valid, 2 invalid, 3 failure",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Earnings List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/payment/list?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"payment",
-								"list"
-							],
-							"query": [
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name",
-									"disabled": true
-								},
-								{
-									"key": "startDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "endDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "pageIndex",
-									"value": "",
-									"description": "Page number, default is first page, start form 1",
-									"disabled": true
-								},
-								{
-									"key": "pageSize",
-									"value": "",
-									"description": "Number of pages, minimum 10, maximum 200",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Extra Bonus List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/payment/other?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"payment",
-								"other"
-							],
-							"query": [
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name",
-									"disabled": true
-								},
-								{
-									"key": "startDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "endDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "pageIndex",
-									"value": "",
-									"description": "Page number, default is first page, start form 1",
-									"disabled": true
-								},
-								{
-									"key": "pageSize",
-									"value": "",
-									"description": "Number of pages, minimum 10, maximum 200",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Hashrate Resale List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/hash-transfer/config/details/list?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"hash-transfer",
-								"config",
-								"details",
-								"list"
-							],
-							"query": [
-								{
-									"key": "pageIndex",
-									"value": "",
-									"description": "Page number, default is first page, start form 1",
-									"disabled": true
-								},
-								{
-									"key": "pageSize",
-									"value": "",
-									"description": "Number of pages, minimum 10, maximum 200",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Hashrate Resale Detail (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/hash-transfer/profit/details?configId=&userName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"hash-transfer",
-								"profit",
-								"details"
-							],
-							"query": [
-								{
-									"key": "configId",
-									"value": "",
-									"description": "Mining ID"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "pageIndex",
-									"value": "",
-									"description": "Page number, default is first page, start form 1",
-									"disabled": true
-								},
-								{
-									"key": "pageSize",
-									"value": "",
-									"description": "Number of pages, minimum 10, maximum 200",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Hashrate Resale Request (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/hash-transfer/config?userName=&algo=&toPoolUser=&hashRate=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"hash-transfer",
-								"config"
-							],
-							"query": [
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "startDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "endDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "toPoolUser",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "hashRate",
-									"value": "",
-									"description": "Resale hashrate h/s must be transferred (BTC is greater than 500000000000 ETH is greater than 500000)"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel hashrate resale configuration (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/hash-transfer/config/cancel?configId=&userName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"hash-transfer",
-								"config",
-								"cancel"
-							],
-							"query": [
-								{
-									"key": "configId",
-									"value": "",
-									"description": "Mining ID"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Statistic List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/statistics/user/status?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"statistics",
-								"user",
-								"status"
-							],
-							"query": [
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Account List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/statistics/user/list?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"statistics",
-								"user",
-								"list"
-							],
-							"query": [
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "userName",
-									"value": "",
-									"description": "Mining Account"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Mining Account Earning (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/mining/payment/uid?algo=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"mining",
-								"payment",
-								"uid"
-							],
-							"query": [
-								{
-									"key": "algo",
-									"value": "",
-									"description": "Algorithm(sha256)"
-								},
-								{
-									"key": "startDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "endDate",
-									"value": "",
-									"description": "Search date, millisecond timestamp, while empty query all",
-									"disabled": true
-								},
-								{
-									"key": "pageIndex",
-									"value": "",
-									"description": "Page number, default is first page, start form 1",
-									"disabled": true
-								},
-								{
-									"key": "pageSize",
-									"value": "",
-									"description": "Number of pages, minimum 10, maximum 200",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 5"
-					},
-					"response": []
-				}],
-			"description": "Mining Endpoints"
-		},
-		{
-			"name": "NFT",
-			"item": [
-				{
-					"name": "Get NFT Transaction History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/history/transactions?orderType=1&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"history",
-								"transactions"
-							],
-							"query": [
-								{
-									"key": "orderType",
-									"value": "1",
-									"description": "0: purchase order, 1: sell order, 2: royalty income, 3: primary market order, 4: mint fee"
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "50",
-									"description": "Default 50, Max 50",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Get NFT Deposit History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/history/deposit?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"history",
-								"deposit"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "50",
-									"description": "Default 50, Max 50",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Get NFT Withdraw History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/history/withdraw?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"history",
-								"withdraw"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "50",
-									"description": "Default 50, Max 50",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Get NFT Asset (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/nft/user/getAsset?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"nft",
-								"user",
-								"getAsset"
-							],
-							"query": [
-								{
-									"key": "limit",
-									"value": "50",
-									"description": "Default 50, Max 50",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(UID): 3000"
-					},
-					"response": []
-				}],
-			"description": "NFT Endpoints"
-		},
-		{
-			"name": "Pay",
-			"item": [
-				{
-					"name": "Get Pay Trade History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/pay/transactions?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"pay",
-								"transactions"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "100",
-									"description": "default 100, max 100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If startTimestamp and endTimestamp are not sent, the recent 90 days' data will be returned.\n- The max interval between startTimestamp and endTimestamp is 90 days.\n- Support for querying orders within the last 18 months.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				}],
-			"description": "Pay Endpoints"
-		},
-		{
-			"name": "Portfolio Margin",
-			"item": [
-				{
-					"name": "Get Portfolio Margin Account Info (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/portfolio/account?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"portfolio",
-								"account"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Portfolio Margin Collateral Rate (MARKET_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/portfolio/collateralRate",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"portfolio",
-								"collateralRate"
-							]
-						},
-						"description": "Portfolio Margin Collateral Rate.\n\nWeight(IP): 50"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Portfolio Margin Bankruptcy Loan Amount (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/portfolio/pmLoan?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"portfolio",
-								"pmLoan"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Query Portfolio Margin Bankruptcy Loan Amount.\n\nWeight(UID): 500"
-					},
-					"response": []
-				},
-				{
-					"name": "Portfolio Margin Bankruptcy Loan Repay (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/portfolio/repay?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"portfolio",
-								"repay"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Repay Portfolio Margin Bankruptcy Loan.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				}],
-			"description": "The Binance Portfolio Margin Program is a cross-asset margin program supporting consolidated margin balance across trading products with over 200+ effective crypto collaterals. It is designed for professional traders, market makers, and institutional users looking to actively trade & hedge cross-asset and optimize risk-management in a consolidated setup."
-		},
-		{
-			"name": "Rebate",
-			"item": [
-				{
-					"name": "Get Spot Rebate History Records (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/rebate/taxQuery?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"rebate",
-								"taxQuery"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "default 1",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n- The earliest startTime is supported on June 10, 2020\n\nWeight(UID): 3000"
-					},
-					"response": []
-				}],
-			"description": "Rebate Endpoints"
-		},
-		{
-			"name": "Savings",
-			"item": [
-				{
-					"name": "Get Flexible Product List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/product/list?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"daily",
-								"product",
-								"list"
-							],
-							"query": [
-								{
-									"key": "status",
-									"value": "",
-									"description": "Default `ALL`",
-									"disabled": true
-								},
-								{
-									"key": "featured",
-									"value": "",
-									"description": "Default `ALL`",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Left Daily Purchase Quota of Flexible Product (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/userLeftQuota?productId=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"daily",
-								"userLeftQuota"
-							],
-							"query": [
-								{
-									"key": "productId",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Purchase Flexible Product (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/purchase?productId=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"daily",
-								"purchase"
-							],
-							"query": [
-								{
-									"key": "productId",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Left Daily Redemption Quota of Flexible Product (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/userRedemptionQuota?productId=&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"daily",
-								"userRedemptionQuota"
-							],
-							"query": [
-								{
-									"key": "productId",
-									"value": ""
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "\"FAST\", \"NORMAL\""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Redeem Flexible Product (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/redeem?productId=&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"daily",
-								"redeem"
-							],
-							"query": [
-								{
-									"key": "productId",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "\"FAST\", \"NORMAL\""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Flexible Product Position (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/daily/token/position?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"daily",
-								"token",
-								"position"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Fixed and Activity Project List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/project/list?type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"project",
-								"list"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "\"ACTIVITY\", \"CUSTOMIZED_FIXED\""
-								},
-								{
-									"key": "status",
-									"value": "",
-									"description": "Default `ALL`",
-									"disabled": true
-								},
-								{
-									"key": "isSortAsc",
-									"value": "",
-									"description": "default \"true\"",
-									"disabled": true
-								},
-								{
-									"key": "sortBy",
-									"value": "",
-									"description": "Default `START_TIME`",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Purchase Fixed/Activity Project (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/customizedFixed/purchase?projectId=&lot=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"customizedFixed",
-								"purchase"
-							],
-							"query": [
-								{
-									"key": "projectId",
-									"value": ""
-								},
-								{
-									"key": "lot",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Fixed/Activity Project Position (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/project/position/list?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"project",
-								"position",
-								"list"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "projectId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "status",
-									"value": "",
-									"description": "Default `ALL`",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Lending Account (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/union/account?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"union",
-								"account"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Purchase Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/union/purchaseRecord?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"union",
-								"purchaseRecord"
-							],
-							"query": [
-								{
-									"key": "lendingType",
-									"value": "",
-									"description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
-								},
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeigh(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Redemption Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/union/redemptionRecord?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"union",
-								"redemptionRecord"
-							],
-							"query": [
-								{
-									"key": "lendingType",
-									"value": "",
-									"description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
-								},
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Interest History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/union/interestHistory?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"union",
-								"interestHistory"
-							],
-							"query": [
-								{
-									"key": "lendingType",
-									"value": "",
-									"description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
-								},
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Change Fixed/Activity Position to Daily Position (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/lending/positionChanged?projectId=&lot=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"lending",
-								"positionChanged"
-							],
-							"query": [
-								{
-									"key": "projectId",
-									"value": ""
-								},
-								{
-									"key": "lot",
-									"value": ""
-								},
-								{
-									"key": "positionId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- PositionId is mandatory parameter for fixed position.\n\nWeight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": "Savings Endpoints"
-		},
-		{
-			"name": "Staking",
-			"item": [
-				{
-					"name": "Get Staking Product List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/staking/productList?product=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"staking",
-								"productList"
-							],
-							"query": [
-								{
-									"key": "product",
-									"value": "",
-									"description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
-								},
-								{
-									"key": "asset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "",
-									"description": "Currently querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "",
-									"description": "Default:10, Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get available Staking product list.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Purchase Staking Product (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/staking/purchase?product=&productId=&amount=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"staking",
-								"purchase"
-							],
-							"query": [
-								{
-									"key": "product",
-									"value": "",
-									"description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
-								},
-								{
-									"key": "productId",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": ""
-								},
-								{
-									"key": "renewable",
-									"value": "",
-									"description": "true or false, default false. Active if product is `STAKING` or `L_DEFI`",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Redeem Staking Product (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/staking/redeem?product=&productId=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"staking",
-								"redeem"
-							],
-							"query": [
-								{
-									"key": "product",
-									"value": "",
-									"description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
-								},
-								{
-									"key": "positionId",
-									"value": "",
-									"description": "Mandatory if product is `STAKING` or `L_DEFI`",
-									"disabled": true
-								},
-								{
-									"key": "productId",
-									"value": ""
-								},
-								{
-									"key": "amount",
-									"value": "",
-									"description": "Mandatory if product is `F_DEFI`",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Redeem Staking product. Locked staking and Locked DeFI staking belong to early redemption, redeeming in advance will result in loss of interest that you have earned.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Staking Product Position (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/staking/position?product=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"staking",
-								"position"
-							],
-							"query": [
-								{
-									"key": "product",
-									"value": "",
-									"description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
-								},
-								{
-									"key": "productId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "asset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "",
-									"description": "Currently querying the page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "",
-									"description": "Default:10, Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Staking History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/staking/stakingRecord?product=&txnType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"staking",
-								"stakingRecord"
-							],
-							"query": [
-								{
-									"key": "product",
-									"value": "",
-									"description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
-								},
-								{
-									"key": "txnType",
-									"value": "",
-									"description": "`SUBSCRIPTION`, `REDEMPTION`, `INTEREST`"
-								},
-								{
-									"key": "asset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "",
-									"description": "Currently querying the page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "",
-									"description": "Default:10, Max:100",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Set Auto Staking (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/staking/setAutoStaking?product=&positionId=&renewable=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"staking",
-								"setAutoStaking"
-							],
-							"query": [
-								{
-									"key": "product",
-									"value": "",
-									"description": "* `STAKING` - for Locked Staking\n* `L_DEFI` - for locked DeFi Staking"
-								},
-								{
-									"key": "positionId",
-									"value": ""
-								},
-								{
-									"key": "renewable",
-									"value": "",
-									"description": "true or false"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Set auto staking on Locked Staking or Locked DeFi Staking\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Personal Left Quota of Staking Product (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/staking/personalLeftQuota?product=&productId=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"staking",
-								"personalLeftQuota"
-							],
-							"query": [
-								{
-									"key": "product",
-									"value": "",
-									"description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
-								},
-								{
-									"key": "productId",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": ""
-		},
-		{
-			"name": "Sub-Account",
-			"item": [
-				{
-					"name": "Create a Virtual Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/virtualSubAccount?subAccountString=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"virtualSubAccount"
-							],
-							"query": [
-								{
-									"key": "subAccountString",
-									"value": "",
-									"description": "Please input a string. We will create a virtual email using that string for you to register"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- This request will generate a virtual sub account under your master account.\n- You need to enable \"trade\" option for the api key which requests this endpoint.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account List (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/list?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"list"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "isFreeze",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "1",
-									"description": "Default 1; max 200",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Spot Asset Transfer History (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/sub/transfer/history?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"sub",
-								"transfer",
-								"history"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "toEmail",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- fromEmail and toEmail cannot be sent at the same time.\n- Return fromEmail equal master account email by default.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Futures Asset Transfer History (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?email=&futuresType=2&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"internalTransfer"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "futuresType",
-									"value": "2",
-									"description": "1:USDT-margined Futures, 2: Coin-margined Futures"
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "Default value: 50, Max value: 500",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Sub-account Futures Asset Transfer (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?fromEmail=&toEmail=&futuresType=2&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"internalTransfer"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"description": "Sender email"
-								},
-								{
-									"key": "toEmail",
-									"value": "",
-									"description": "Recipient email"
-								},
-								{
-									"key": "futuresType",
-									"value": "2",
-									"description": "1:USDT-margined Futures,2: Coin-margined Futures"
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Master account can transfer max 2000 times a minute\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Assets (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v3/sub-account/assets?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v3",
-								"sub-account",
-								"assets"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch sub-account assets\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Sub-account Spot Assets Summary (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/spotSummary?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"spotSummary"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "",
-									"description": "Default:10 Max:20",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get BTC valued asset summary of subaccounts.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Sub-account Deposit Address (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/subAddress?email=&coin=BNB&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"subAddress"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name"
-								},
-								{
-									"key": "network",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch sub-account deposit address\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Sub-account Deposit History (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/subHisrec?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"subHisrec"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name",
-									"disabled": true
-								},
-								{
-									"key": "status",
-									"value": "",
-									"description": "0(0:pending,6: credited but cannot withdraw, 1:success)",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "offset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch sub-account deposit history\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Sub-account's Status on Margin/Futures (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/status?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"status"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If no `email` sent, all sub-accounts' information will be returned.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Margin for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/enable?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"enable"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Detail on Sub-account's Margin Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/account?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"account"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Summary of Sub-account's Margin Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"accountSummary"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Futures for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/enable?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"enable"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Detail on Sub-account's Futures Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/account?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"account"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Summary of Sub-account's Futures Account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"accountSummary"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Futures Position-Risk of Sub-account (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/positionRisk?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"positionRisk"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Futures Transfer for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/futures/transfer?email=&asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"futures",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "* `1` - transfer from subaccount's spot account to its USDT-margined futures account\n* `2` - transfer from subaccount's USDT-margined futures account to its spot account\n* `3` - transfer from subaccount's spot account to its COIN-margined futures account\n* `4` - transfer from subaccount's COIN-margined futures account to its spot account"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Margin Transfer for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/margin/transfer?email=&asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"margin",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "* `1` - transfer from subaccount's spot account to margin account\n* `2` - transfer from subaccount's margin account to its spot account"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Transfer to Sub-account of Same Master (For Sub-account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/transfer/subToSub?toEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"transfer",
-								"subToSub"
-							],
-							"query": [
-								{
-									"key": "toEmail",
-									"value": "",
-									"description": "Recipient email"
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Transfer to Master (For Sub-account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/transfer/subToMaster?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"transfer",
-								"subToMaster"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Sub-account Transfer History (For Sub-account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/transfer/subUserHistory?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"transfer",
-								"subUserHistory"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "* `1` - transfer in\n* `2` - transfer out",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- If `type` is not sent, the records of type 2: transfer out will be returned by default.\n- If `startTime` and `endTime` are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Universal Transfer History (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/universalTransfer?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"universalTransfer"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "toEmail",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "clientTranId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "Default 500, Max 500",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- `fromEmail` and `toEmail` cannot be sent at the same time.\n- Return `fromEmail` equal master account email by default.\n- The query time period must be less then 30 days.\n- If startTime and endTime not sent, return records of the last 30 days by default.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Universal Transfer (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/universalTransfer?fromAccountType=&toAccountType=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"universalTransfer"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "toEmail",
-									"value": "",
-									"description": "Sub-account email",
-									"disabled": true
-								},
-								{
-									"key": "fromAccountType",
-									"value": ""
-								},
-								{
-									"key": "toAccountType",
-									"value": ""
-								},
-								{
-									"key": "clientTranId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "symbol",
-									"value": "",
-									"description": "Only supported under ISOLATED_MARGIN type",
-									"disabled": true
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- You need to enable \"internal transfer\" option for the api key which requests this endpoint.\n- Transfer from master account by default if fromEmail is not sent.\n- Transfer to master account by default if toEmail is not sent.\n- Transfer between futures accounts is not supported.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Detail on Sub-account's Futures Account V2 (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/sub-account/futures/account?email=&futuresType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"sub-account",
-								"futures",
-								"account"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "futuresType",
-									"value": "",
-									"description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Summary of Sub-account's Futures Account V2 (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/sub-account/futures/accountSummary?futuresType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"sub-account",
-								"futures",
-								"accountSummary"
-							],
-							"query": [
-								{
-									"key": "futuresType",
-									"value": "",
-									"description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
-								},
-								{
-									"key": "page",
-									"value": "1",
-									"description": "Default 1",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "Default 10, Max 20",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Futures Position-Risk of Sub-account V2 (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v2/sub-account/futures/positionRisk?email=&futuresType=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v2",
-								"sub-account",
-								"futures",
-								"positionRisk"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "futuresType",
-									"value": "",
-									"description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Leverage Token for Sub-account (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/blvt/enable?email=&enableBlvt=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"blvt",
-								"enable"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "enableBlvt",
-									"value": "",
-									"description": "Only true for now"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Deposit assets into the managed sub-account (For Investor Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/managed-subaccount/deposit?toEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"managed-subaccount",
-								"deposit"
-							],
-							"query": [
-								{
-									"key": "toEmail",
-									"value": "",
-									"description": "Recipient email"
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query managed sub-account asset details (For Investor Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/managed-subaccount/asset?email=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"managed-subaccount",
-								"asset"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Withdrawl assets from the managed sub-account (For Investor Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/managed-subaccount/withdraw?fromEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"managed-subaccount",
-								"withdraw"
-							],
-							"query": [
-								{
-									"key": "fromEmail",
-									"value": "",
-									"description": "Sender email"
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "transferDate",
-									"value": "",
-									"description": "Withdrawals is automatically occur on the transfer date(UTC0). If a date is not selected, the withdrawal occurs right now",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query managed sub-account snapshot (For Investor Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/managed-subaccount/accountSnapshot?email=testaccount@email.com&type=SPOT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"managed-subaccount",
-								"accountSnapshot"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "testaccount@email.com"
-								},
-								{
-									"key": "type",
-									"value": "SPOT",
-									"description": "\"SPOT\", \"MARGIN\"（cross）, \"FUTURES\"（UM）"
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"description": "min 7, max 30, default 7",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The query time period must be less then 30 days\n- Support query within the last one month only\n- If `startTime` and `endTime` not sent, return records of the last 7 days by default\n\nWeight(IP): 2400"
-					},
-					"response": []
-				},
-				{
-					"name": "Enable or Disable IP Restriction for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&ipRestrict=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "ipRestrict",
-									"value": "",
-									"description": "true or false"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Get IP Restriction for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Add IP List for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction",
-								"ipList"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "ipAddress",
-									"value": "",
-									"description": "Can be added in batches, separated by commas"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Before the usage of this endpoint, please ensure `POST /sapi/v1/sub-account/subAccountApi/ipRestriction` was used to enable the IP restriction.\n\nWeight(UID): 3000"
-					},
-					"response": []
-				},
-				{
-					"name": "Delete IP List for a Sub-account API Key (For Master Account)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"sub-account",
-								"subAccountApi",
-								"ipRestriction",
-								"ipList"
-							],
-							"query": [
-								{
-									"key": "email",
-									"value": "",
-									"description": "Sub-account email"
-								},
-								{
-									"key": "subAccountApiKey",
-									"value": ""
-								},
-								{
-									"key": "ipAddress",
-									"value": "",
-									"description": "Can be added in batches, separated by commas"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(UID): 3000"
-					},
-					"response": []
-				}],
-			"description": "Sub-account Endpoints"
-		},
-		{
-			"name": "Trade",
-			"item": [
-				{
-					"name": "Test New Order (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order/test?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order",
-								"test"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "side",
-									"value": "SELL"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "Order type"
-								},
-								{
-									"key": "timeInForce",
-									"value": "",
-									"description": "Order time in force",
-									"disabled": true
-								},
-								{
-									"key": "quantity",
-									"value": "",
-									"description": "Order quantity",
-									"disabled": true
-								},
-								{
-									"key": "quoteOrderQty",
-									"value": "",
-									"description": "Quote quantity",
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": "",
-									"description": "Order price",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "strategyId",
-									"value": "",
-									"description": "",
-									"disabled": true
-								},
-								{
-									"key": "strategyType",
-									"value": "",
-									"description": "The value cannot be less than 1000000",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": "20.01",
-									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
-									"disabled": true
-								},
-								{
-									"key": "trailingDelta",
-									"value": "",
-									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
-									"disabled": true
-								},
-								{
-									"key": "icebergQty",
-									"value": "",
-									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": "",
-									"description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Test new order creation and signature/recvWindow long.\nCreates and validates a new order but does not send it into the matching engine.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Order (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"description": "Order id",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"description": "Order id from client",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Check an order's status.\n\n- Either `orderId` or `origClientOrderId` must be sent.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 2"
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel an Existing Order and Send a New Order (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order/cancelReplace?symbol=BNBUSDT&side=SELL&type=&cancelReplaceMode=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order",
-								"cancelReplace"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "side",
-									"value": "SELL"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "Order type"
-								},
-								{
-									"key": "cancelReplaceMode",
-									"value": "",
-									"description": "- `STOP_ON_FAILURE` If the cancel request fails, the new order placement will not be attempted.\n- `ALLOW_FAILURES` If new order placement will be attempted even if cancel request fails."
-								},
-								{
-									"key": "timeInForce",
-									"value": "",
-									"description": "Order time in force",
-									"disabled": true
-								},
-								{
-									"key": "quantity",
-									"value": "",
-									"description": "Order quantity",
-									"disabled": true
-								},
-								{
-									"key": "quoteOrderQty",
-									"value": "",
-									"description": "Quote quantity",
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": "",
-									"description": "Order price",
-									"disabled": true
-								},
-								{
-									"key": "cancelNewClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "cancelOrigClientOrderId",
-									"value": "",
-									"description": "Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.",
-									"disabled": true
-								},
-								{
-									"key": "cancelOrderId",
-									"value": "",
-									"description": "Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to identify the new order. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "strategyId",
-									"value": "",
-									"description": "",
-									"disabled": true
-								},
-								{
-									"key": "strategyType",
-									"value": "",
-									"description": "The value cannot be less than 1000000",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": "20.01",
-									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
-									"disabled": true
-								},
-								{
-									"key": "trailingDelta",
-									"value": "",
-									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
-									"disabled": true
-								},
-								{
-									"key": "icebergQty",
-									"value": "",
-									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": "",
-									"description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Cancels an existing order and places a new order on the same symbol.\n\nFilters are evaluated before the cancel order is placed.\n\nIf the new order placement is successfully sent to the engine, the order count will increase by 1.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "New Order (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "side",
-									"value": "SELL"
-								},
-								{
-									"key": "type",
-									"value": "",
-									"description": "Order type"
-								},
-								{
-									"key": "timeInForce",
-									"value": "",
-									"description": "Order time in force",
-									"disabled": true
-								},
-								{
-									"key": "quantity",
-									"value": "",
-									"description": "Order quantity",
-									"disabled": true
-								},
-								{
-									"key": "quoteOrderQty",
-									"value": "",
-									"description": "Quote quantity",
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": "",
-									"description": "Order price",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "strategyId",
-									"value": "",
-									"description": "",
-									"disabled": true
-								},
-								{
-									"key": "strategyType",
-									"value": "",
-									"description": "The value cannot be less than 1000000",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": "20.01",
-									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
-									"disabled": true
-								},
-								{
-									"key": "trailingDelta",
-									"value": "",
-									"description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
-									"disabled": true
-								},
-								{
-									"key": "icebergQty",
-									"value": "",
-									"description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": "",
-									"description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Send in a new order.\n\n- `LIMIT_MAKER` are `LIMIT` orders that will be rejected if they would immediately match and trade as a taker.\n- `STOP_LOSS` and `TAKE_PROFIT` will execute a `MARKET` order when the `stopPrice` is reached.\n- Any `LIMIT` or `LIMIT_MAKER` type order can be made an iceberg order by sending an `icebergQty`.\n- Any order with an `icebergQty` MUST have `timeInForce` set to `GTC`.\n- `MARKET` orders using `quantity` specifies how much a user wants to buy or sell based on the market price.\n- `MARKET` orders using `quoteOrderQty` specifies the amount the user wants to spend (when buying) or receive (when selling) of the quote asset; the correct quantity will be determined based on the market liquidity and `quoteOrderQty`.\n- `MARKET` orders using `quoteOrderQty` will not break `LOT_SIZE` filter rules; the order will execute a quantity that will have the notional value as close as possible to `quoteOrderQty`.\n- same `newClientOrderId` can be accepted only when the previous one is filled, otherwise the order will be rejected.\n\nTrigger order price rules against market price for both `MARKET` and `LIMIT` versions:\n\n- Price above market price: `STOP_LOSS` `BUY`, `TAKE_PROFIT` `SELL`\n- Price below market price: `STOP_LOSS` `SELL`, `TAKE_PROFIT` `BUY`\n\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel Order (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"description": "Order id",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"description": "Order id from client",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Cancel an active order.\n\nEither `orderId` or `origClientOrderId` must be sent.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Current Open Orders (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/openOrders?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"openOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get all open orders on a symbol. Careful when accessing this with no symbol.\n\nWeight(IP):\n- `3` for a single symbol;\n- `40` when the symbol parameter is omitted;"
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel all Open Orders on a Symbol (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/openOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"openOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Cancels all active orders on a symbol.\nThis includes OCO orders.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "All Orders (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/allOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"allOrders"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"description": "Order id",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get all account orders; active, canceled, or filled..\n\n- If `orderId` is set, it will get orders >= that `orderId`. Otherwise most recent orders are returned.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n- If `startTime` and/or `endTime` provided, `orderId` is not required\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "New OCO (TRADE)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/order/oco?symbol=BNBUSDT&side=SELL&quantity=&price=&stopPrice=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"order",
-								"oco"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "listClientOrderId",
-									"value": "",
-									"description": "A unique Id for the entire orderList",
-									"disabled": true
-								},
-								{
-									"key": "side",
-									"value": "SELL"
-								},
-								{
-									"key": "quantity",
-									"value": ""
-								},
-								{
-									"key": "limitClientOrderId",
-									"value": "",
-									"description": "A unique Id for the limit order",
-									"disabled": true
-								},
-								{
-									"key": "limitStrategyId",
-									"value": "",
-									"description": "",
-									"disabled": true
-								},
-								{
-									"key": "limitStrategyType",
-									"value": "",
-									"description": "The value cannot be less than 1000000",
-									"disabled": true
-								},
-								{
-									"key": "price",
-									"value": "",
-									"description": "Order price"
-								},
-								{
-									"key": "limitIcebergQty",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "trailingDelta",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "stopClientOrderId",
-									"value": "",
-									"description": "A unique Id for the stop loss/stop loss limit leg",
-									"disabled": true
-								},
-								{
-									"key": "stopPrice",
-									"value": ""
-								},
-								{
-									"key": "stopStrategyId",
-									"value": "",
-									"description": "",
-									"disabled": true
-								},
-								{
-									"key": "stopStrategyType",
-									"value": "",
-									"description": "The value cannot be less than 1000000",
-									"disabled": true
-								},
-								{
-									"key": "stopLimitPrice",
-									"value": "",
-									"description": "If provided, stopLimitTimeInForce is required.",
-									"disabled": true
-								},
-								{
-									"key": "stopIcebergQty",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "stopLimitTimeInForce",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "newOrderRespType",
-									"value": "",
-									"description": "Set the response JSON.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Send in a new OCO\n\n- Price Restrictions:\n  - `SELL`: Limit Price > Last Price > Stop Price\n  - `BUY`: Limit Price < Last Price < Stop Price\n- Quantity Restrictions:\n    - Both legs must have the same quantity\n    - `ICEBERG` quantities however do not have to be the same\n- Order Rate Limit\n    - `OCO` counts as 2 orders against the order rate limit.\n    \nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/orderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"orderList"
-							],
-							"query": [
-								{
-									"key": "orderListId",
-									"value": "",
-									"description": "Order list id",
-									"disabled": true
-								},
-								{
-									"key": "origClientOrderId",
-									"value": "",
-									"description": "Order id from client",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Retrieves a specific OCO based on provided optional parameters\n\nWeight(IP): 2"
-					},
-					"response": []
-				},
-				{
-					"name": "Cancel OCO (TRADE)",
-					"request": {
-						"method": "DELETE",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/orderList?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"orderList"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "orderListId",
-									"value": "",
-									"description": "Order list id",
-									"disabled": true
-								},
-								{
-									"key": "listClientOrderId",
-									"value": "",
-									"description": "A unique Id for the entire orderList",
-									"disabled": true
-								},
-								{
-									"key": "newClientOrderId",
-									"value": "",
-									"description": "Used to uniquely identify this cancel. Automatically generated by default",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Cancel an entire Order List\n\nCanceling an individual leg will cancel the entire OCO\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query all OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/allOrderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"allOrderList"
-							],
-							"query": [
-								{
-									"key": "fromId",
-									"value": "",
-									"description": "Trade id to fetch from. Default gets most recent trades.",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Retrieves all OCO based on provided optional parameters\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Open OCO (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/openOrderList?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"openOrderList"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 3"
-					},
-					"response": []
-				},
-				{
-					"name": "Account Information (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/account?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"account"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get current account information.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Account Trade List (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/myTrades?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"myTrades"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT"
-								},
-								{
-									"key": "orderId",
-									"value": "",
-									"description": "This can only be used in combination with symbol.",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "fromId",
-									"value": "",
-									"description": "Trade id to fetch from. Default gets most recent trades.",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get trades for a specific account and symbol.\n\nIf `fromId` is set, it will get id >= that `fromId`. Otherwise most recent orders are returned.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Query Current Order Count Usage (TRADE)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/api/v3/rateLimit/order?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"api",
-								"v3",
-								"rateLimit",
-								"order"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Displays the user's current order count usage for all intervals.\n\nWeight(IP): 20"
-					},
-					"response": []
-				}],
-			"description": "Account/Trade"
-		},
-		{
-			"name": "User Data Stream",
-			"item": [
-				{
-					"name": "Spot",
-					"item": [
-						{
-							"name": "Create a ListenKey (USER_STREAM)",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/api/v3/userDataStream",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v3",
-										"userDataStream"
-									]
-								},
-								"description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
-							},
-							"response": []
-						},
-						{
-							"name": "Ping/Keep-alive a ListenKey (USER_STREAM)",
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/api/v3/userDataStream?listenKey=listen-key",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v3",
-										"userDataStream"
-									],
-									"query": [
-										{
-											"key": "listenKey",
-											"value": "listen-key",
-											"description": "User websocket listen key"
-										}
-									]
-								},
-								"description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
-							},
-							"response": []
-						},
-						{
-							"name": "Close a ListenKey (USER_STREAM)",
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/api/v3/userDataStream?listenKey=listen-key",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"api",
-										"v3",
-										"userDataStream"
-									],
-									"query": [
-										{
-											"key": "listenKey",
-											"value": "listen-key",
-											"description": "User websocket listen key"
-										}
-									]
-								},
-								"description": "Close out a user data stream.\n\nWeight: 1"
-							},
-							"response": []
-						}],
-					"description": "User Data Stream"
-				},
-				{
-					"name": "Cross Margin",
-					"item": [
-						{
-							"name": "Create a ListenKey (USER_STREAM)",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/userDataStream",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"userDataStream"
-									]
-								},
-								"description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
-							},
-							"response": []
-						},
-						{
-							"name": "Ping/Keep-alive a ListenKey (USER_STREAM)",
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/userDataStream?listenKey=listen-key",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"userDataStream"
-									],
-									"query": [
-										{
-											"key": "listenKey",
-											"value": "listen-key",
-											"description": "User websocket listen key"
-										}
-									]
-								},
-								"description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
-							},
-							"response": []
-						},
-						{
-							"name": "Close a ListenKey (USER_STREAM)",
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/userDataStream?listenKey=listen-key",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"userDataStream"
-									],
-									"query": [
-										{
-											"key": "listenKey",
-											"value": "listen-key",
-											"description": "User websocket listen key"
-										}
-									]
-								},
-								"description": "Close out a user data stream.\n\nWeight: 1"
-							},
-							"response": []
-						}],
-					"description": "Margin User Data Stream"
-				},
-				{
-					"name": "Isolated Margin",
-					"item": [
-						{
-							"name": "Generate a Listen Key (USER_STREAM)",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/userDataStream/isolated?symbol=BTCUSDT",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"userDataStream",
-										"isolated"
-									],
-									"query": [
-										{
-											"key": "symbol",
-											"value": "BTCUSDT"
-										}
-									]
-								},
-								"description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
-							},
-							"response": []
-						},
-						{
-							"name": "Ping/Keep-alive a Listen Key (USER_STREAM)",
-							"request": {
-								"method": "PUT",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/userDataStream/isolated?symbol=BTCUSDT&listenKey=listen-key",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"userDataStream",
-										"isolated"
-									],
-									"query": [
-										{
-											"key": "symbol",
-											"value": "BTCUSDT"
-										},
-										{
-											"key": "listenKey",
-											"value": "listen-key",
-											"description": "User websocket listen key"
-										}
-									]
-								},
-								"description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
-							},
-							"response": []
-						},
-						{
-							"name": "Close a ListenKey (USER_STREAM)",
-							"request": {
-								"method": "DELETE",
-								"header": [
-									{
-										"key": "Content-Type",
-										"type": "text",
-										"value": "application/json"
-									},
-									{
-										"key": "X-MBX-APIKEY",
-										"value": "{{binance-api-key}}",
-										"type": "text"
-									}
-								],
-								"url": {
-									"raw": "{{url}}/sapi/v1/userDataStream/isolated?symbol=BTCUSDT&listenKey=listen-key",
-									"host": [
-										"{{url}}"
-									],
-									"path": [
-										"sapi",
-										"v1",
-										"userDataStream",
-										"isolated"
-									],
-									"query": [
-										{
-											"key": "symbol",
-											"value": "BTCUSDT"
-										},
-										{
-											"key": "listenKey",
-											"value": "listen-key",
-											"description": "User websocket listen key"
-										}
-									]
-								},
-								"description": "Close out a user data stream.\n\nWeight: 1"
-							},
-							"response": []
-						}],
-					"description": "Isolated User Data Stream"
-				}],
-			"description": ""
-		},
-		{
-			"name": "Wallet",
-			"item": [
-				{
-					"name": "System Status (System)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/system/status",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"system",
-								"status"
-							]
-						},
-						"description": "Fetch system status.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "All Coins' Information (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/config/getall?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"config",
-								"getall"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get information of coins (available for deposit and withdraw) for user.\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Daily Account Snapshot (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/accountSnapshot?type=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"accountSnapshot"
-							],
-							"query": [
-								{
-									"key": "type",
-									"value": "",
-									"description": "\"SPOT\", \"MARGIN\", \"FUTURES\""
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- The query time period must be less than 30 days\n- Support query within the last one month only\n- If startTimeand endTime not sent, return records of the last 7 days by default\n\nWeight(IP): 2400"
-					},
-					"response": []
-				},
-				{
-					"name": "Disable Fast Withdraw Switch (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/disableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"disableFastWithdrawSwitch"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- This request will disable fastwithdraw switch under your account.\n- You need to enable \"trade\" option for the api key which requests this endpoint.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Enable Fast Withdraw Switch (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/enableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"enableFastWithdrawSwitch"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- This request will enable fastwithdraw switch under your account. You need to enable \"trade\" option for the api key which requests this endpoint.\n- When Fast Withdraw Switch is on, transferring funds to a Binance account will be done instantly. There is no on-chain transaction, no transaction ID and no withdrawal fee.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Withdraw (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/withdraw/apply?coin=BNB&address=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"withdraw",
-								"apply"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name"
-								},
-								{
-									"key": "withdrawOrderId",
-									"value": "",
-									"description": "Client id for withdraw",
-									"disabled": true
-								},
-								{
-									"key": "network",
-									"value": "",
-									"description": "Get the value from `GET /sapi/v1/capital/config/getall`",
-									"disabled": true
-								},
-								{
-									"key": "address",
-									"value": ""
-								},
-								{
-									"key": "addressTag",
-									"value": "",
-									"description": "Secondary address identifier for coins like XRP,XMR etc.",
-									"disabled": true
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "transactionFeeFlag",
-									"value": "",
-									"description": "When making internal transfer\n- `true` ->  returning the fee to the destination account;\n- `false` -> returning the fee back to the departure account.",
-									"disabled": true
-								},
-								{
-									"key": "name",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "walletType",
-									"value": "",
-									"description": "The wallet type for withdraw，0-Spot wallet, 1- Funding wallet. Default is Spot wallet",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Submit a withdraw request.\n\n- If `network` not send, return with default network of the coin.\n- You can get `network` and `isDefault` in `networkList` of a coin in the response of `Get /sapi/v1/capital/config/getall (HMAC SHA256)`.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Deposit History (supporting network) (User Data)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/hisrec?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"hisrec"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name",
-									"disabled": true
-								},
-								{
-									"key": "status",
-									"value": "",
-									"description": "* `0` - pending\n* `6` - credited but cannot withdraw\n* `1` - success",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "offset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch deposit history.\n\n- Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.\n- If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Withdraw History (supporting network) (User Data)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/withdraw/history?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"withdraw",
-								"history"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name",
-									"disabled": true
-								},
-								{
-									"key": "withdrawOrderId",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "status",
-									"value": "",
-									"description": "* `0` - Email Sent\n* `1` - Cancelled\n* `2` - Awaiting Approval\n* `3` - Rejected\n* `4` - Processing\n* `5` - Failure\n* `6` - Completed",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "offset",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "500",
-									"description": "Default 500; max 1000.",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch withdraw history.\n\n- `network` may not be in the response for old withdraw.\n- Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.\n- If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Deposit Address (supporting network) (User Data)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/capital/deposit/address?coin=BNB&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"capital",
-								"deposit",
-								"address"
-							],
-							"query": [
-								{
-									"key": "coin",
-									"value": "BNB",
-									"description": "Coin name"
-								},
-								{
-									"key": "network",
-									"value": "ETH",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch deposit address with network.\n\n- If network is not send, return with default network of the coin.\n- You can get network and isDefault in networkList in the response of Get /sapi/v1/capital/config/getall (HMAC SHA256).\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Account Status (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/status?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"status"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch account status detail.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Account API Trading Status (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/apiTradingStatus?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"apiTradingStatus"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch account API trading status with details.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "DustLog (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/dribblet?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"dribblet"
-							],
-							"query": [
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Get Assets That Can Be Converted Into BNB (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/dust-btc?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"dust-btc"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Dust Transfer (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/dust?asset=&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"dust"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "",
-									"description": "The asset being converted. For example, asset=BTC&asset=USDT"
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Convert dust assets to BNB.\n\nWeight(UID): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Asset Dividend Record (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/assetDividend?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"assetDividend"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "limit",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Query asset Dividend Record\n\nWeight(IP): 10"
-					},
-					"response": []
-				},
-				{
-					"name": "Asset Detail (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/assetDetail?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"assetDetail"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch details of assets supported on Binance.\n\n- Please get network and other deposit or withdraw details from `GET /sapi/v1/capital/config/getall`.\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Trade Fee (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/tradeFee?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"tradeFee"
-							],
-							"query": [
-								{
-									"key": "symbol",
-									"value": "BNBUSDT",
-									"description": "Trading symbol, e.g. BNBUSDT",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Fetch trade fee\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Query User Universal Transfer History (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/transfer?type=MAIN_UMFUTURE&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "type",
-									"value": "MAIN_UMFUTURE",
-									"description": "Universal transfer type"
-								},
-								{
-									"key": "startTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "endTime",
-									"value": "",
-									"description": "UTC timestamp in ms",
-									"disabled": true
-								},
-								{
-									"key": "current",
-									"value": "1",
-									"description": "Current querying page. Start from 1. Default:1",
-									"disabled": true
-								},
-								{
-									"key": "size",
-									"value": "100",
-									"description": "Default:10 Max:100",
-									"disabled": true
-								},
-								{
-									"key": "fromSymbol",
-									"value": "BNBUSDT",
-									"description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
-									"disabled": true
-								},
-								{
-									"key": "toSymbol",
-									"value": "BNBUSDT",
-									"description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- Support query within the last 6 months only\n- If `startTime` and `endTime` not sent, return records of the last 7 days by default\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "User Universal Transfer (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/transfer?type=MAIN_UMFUTURE&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"transfer"
-							],
-							"query": [
-								{
-									"key": "type",
-									"value": "MAIN_UMFUTURE",
-									"description": "Universal transfer type"
-								},
-								{
-									"key": "asset",
-									"value": "BTC"
-								},
-								{
-									"key": "amount",
-									"value": "1.01"
-								},
-								{
-									"key": "fromSymbol",
-									"value": "BNBUSDT",
-									"description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
-									"disabled": true
-								},
-								{
-									"key": "toSymbol",
-									"value": "BNBUSDT",
-									"description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "You need to enable `Permits Universal Transfer` option for the api key which requests this endpoint.\n\n- `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n\nENUM of transfer types:\n- MAIN_UMFUTURE Spot account transfer to USDⓈ-M Futures account\n- MAIN_CMFUTURE Spot account transfer to COIN-M Futures account\n- MAIN_MARGIN Spot account transfer to Margin（cross）account\n- UMFUTURE_MAIN USDⓈ-M Futures account transfer to Spot account\n- UMFUTURE_MARGIN USDⓈ-M Futures account transfer to Margin（cross）account\n- CMFUTURE_MAIN COIN-M Futures account transfer to Spot account\n- CMFUTURE_MARGIN COIN-M Futures account transfer to Margin(cross) account\n- MARGIN_MAIN Margin（cross）account transfer to Spot account\n- MARGIN_UMFUTURE Margin（cross）account transfer to USDⓈ-M Futures\n- MARGIN_CMFUTURE Margin（cross）account transfer to COIN-M Futures\n- ISOLATEDMARGIN_MARGIN Isolated margin account transfer to Margin(cross) account\n- MARGIN_ISOLATEDMARGIN Margin(cross) account transfer to Isolated margin account\n- ISOLATEDMARGIN_ISOLATEDMARGIN Isolated margin account transfer to Isolated margin account\n- MAIN_FUNDING Spot account transfer to Funding account\n- FUNDING_MAIN Funding account transfer to Spot account\n- FUNDING_UMFUTURE Funding account transfer to UMFUTURE account\n- UMFUTURE_FUNDING UMFUTURE account transfer to Funding account\n- MARGIN_FUNDING MARGIN account transfer to Funding account\n- FUNDING_MARGIN Funding account transfer to Margin account\n- FUNDING_CMFUTURE Funding account transfer to CMFUTURE account\n- CMFUTURE_FUNDING CMFUTURE account transfer to Funding account\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "Funding Wallet (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/asset/get-funding-asset?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"asset",
-								"get-funding-asset"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"disabled": true
-								},
-								{
-									"key": "needBtcValuation",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "- Currently supports querying the following business assets：Binance Pay, Binance Card, Binance Gift Card, Stock Token\n\nWeight(IP): 1"
-					},
-					"response": []
-				},
-				{
-					"name": "User Asset (USER_DATA)",
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v3/asset/getUserAsset?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v3",
-								"asset",
-								"getUserAsset"
-							],
-							"query": [
-								{
-									"key": "asset",
-									"value": "BNB",
-									"description": "If asset is blank, then query all positive assets user have.",
-									"disabled": true
-								},
-								{
-									"key": "needBtcValuation",
-									"value": "",
-									"disabled": true
-								},
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Get user assets, just for positive data.\n\nWeight(IP): 5"
-					},
-					"response": []
-				},
-				{
-					"name": "Get API Key Permission (USER_DATA)",
-					"request": {
-						"method": "GET",
-						"header": [
-							{
-								"key": "Content-Type",
-								"type": "text",
-								"value": "application/json"
-							},
-							{
-								"key": "X-MBX-APIKEY",
-								"value": "{{binance-api-key}}",
-								"type": "text"
-							}
-						],
-						"url": {
-							"raw": "{{url}}/sapi/v1/account/apiRestrictions?timestamp={{timestamp}}&signature={{signature}}",
-							"host": [
-								"{{url}}"
-							],
-							"path": [
-								"sapi",
-								"v1",
-								"account",
-								"apiRestrictions"
-							],
-							"query": [
-								{
-									"key": "recvWindow",
-									"value": "5000",
-									"description": "The value cannot be greater than 60000",
-									"disabled": true
-								},
-								{
-									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "UTC timestamp in ms"
-								},
-								{
-									"key": "signature",
-									"value": "{{signature}}",
-									"description": "Signature"
-								}
-							]
-						},
-						"description": "Weight(IP): 1"
-					},
-					"response": []
-				}],
-			"description": "Wallet Endpoints"
-		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					"const ts  = Date.now();",
-					"pm.environment.set(\"timestamp\", ts);",
-					"",
-					"let paramsObject = {};",
-					"",
-					"const binance_api_secret = pm.environment.get(\"binance-api-secret\");",
-					"",
-					"const parameters = pm.request.url.query;",
-					"",
-					"parameters.map((param) => {",
-					"    if (param.key != 'signature' && ",
-					"        param.key != 'timestamp' && ",
-					"        !is_empty(param.value) &&",
-					"        !is_disabled(param.disabled)) {",
-					"            paramsObject[param.key] = param.value;",
-					"            //console.log(encodeURIComponent(param.value));",
-					"            //pm.environment.set(param.key, encodeURIComponent(param.value));",
-					"    }",
-					"})",
-					"        ",
-					"Object.assign(paramsObject, {'timestamp': ts});",
-					"",
-					"if (binance_api_secret) {",
-					"    const queryString = Object.keys(paramsObject).map((key) => {",
-					"        return `${key}=${paramsObject[key]}`;",
-					"    }).join('&');",
-					"    console.log(queryString);",
-					"    const signature = CryptoJS.HmacSHA256(queryString, binance_api_secret).toString();",
-					"    pm.environment.set(\"signature\", signature);",
-					"}",
-					"",
-					"",
-					"function is_disabled(str) {",
-					"    return str == true;",
-					"}",
-					"",
-					"function is_empty(str) {",
-					"    if (typeof str == 'undefined' ||",
-					"        !str || ",
-					"        str.length === 0 || ",
-					"        str === \"\" ||",
-					"        !/[^\\s]/.test(str) ||",
-					"        /^\\s*$/.test(str) ||",
-					"        str.replace(/\\s/g,\"\") === \"\")",
-					"    {",
-					"        return true;",
-					"    }",
-					"    else",
-					"    {",
-					"        return false;",
-					"    }",
-					"}"
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		}
-	]
+  "info": {
+    "_postman_id": "9b22864c-c1e4-4537-97ae-a8c00effc5ed",
+    "name": "Binance spot API",
+    "description": "Binance official supported Postman collections.<br/>\n- API documents: https://binance-docs.github.io/apidocs/spot/en/#change-log\n- Telegram: https://t.me/binance_api_english\n- Open Issue at: https://github.com/binance-exchange/binance-api-postman",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "BLVT",
+      "item": [
+        {
+          "name": "Get BLVT Info (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/blvt/tokenInfo",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "blvt", "tokenInfo"],
+              "query": [
+                {
+                  "key": "tokenName",
+                  "value": "",
+                  "description": "BTCDOWN, BTCUP",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Subscribe BLVT (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/blvt/subscribe?tokenName=&cost=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "blvt", "subscribe"],
+              "query": [
+                {
+                  "key": "tokenName",
+                  "value": "",
+                  "description": "BTCDOWN, BTCUP"
+                },
+                {
+                  "key": "cost",
+                  "value": "",
+                  "description": "Spot balance"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Subscription Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/blvt/subscribe/record?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "blvt", "subscribe", "record"],
+              "query": [
+                {
+                  "key": "tokenName",
+                  "value": "",
+                  "description": "BTCDOWN, BTCUP",
+                  "disabled": true
+                },
+                {
+                  "key": "id",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Only the data of the latest 90 days is available\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Redeem BLVT (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/blvt/redeem?tokenName=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "blvt", "redeem"],
+              "query": [
+                {
+                  "key": "tokenName",
+                  "value": "",
+                  "description": "BTCDOWN, BTCUP"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Redemption Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/blvt/redeem/record?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "blvt", "redeem", "record"],
+              "query": [
+                {
+                  "key": "tokenName",
+                  "value": "",
+                  "description": "BTCDOWN, BTCUP",
+                  "disabled": true
+                },
+                {
+                  "key": "id",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "default 1000, max 1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Only the data of the latest 90 days is available\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get BLVT User Limit Info (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/blvt/userLimit?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "blvt", "userLimit"],
+              "query": [
+                {
+                  "key": "tokenName",
+                  "value": "",
+                  "description": "BTCDOWN, BTCUP",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": "Binance Leveraged Tokens Endpoints"
+    },
+    {
+      "name": "BSwap",
+      "item": [
+        {
+          "name": "List All Swap Pools (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/pools",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "pools"]
+            },
+            "description": "Get metadata about all swap pools.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get liquidity information of a pool (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/liquidity?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "liquidity"],
+              "query": [
+                {
+                  "key": "poolId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get liquidity information and user share of a pool.\n\nWeight(IP):\n- `1` for one pool;\n- `10` when the poolId parameter is omitted;"
+          },
+          "response": []
+        },
+        {
+          "name": "Add Liquidity (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/liquidityAdd?poolId=&asset=BTC&quantity=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "liquidityAdd"],
+              "query": [
+                {
+                  "key": "poolId",
+                  "value": ""
+                },
+                {
+                  "key": "type",
+                  "value": "Single",
+                  "description": "* `Single` - to add a single token\n* `Combination` - to add dual tokens",
+                  "disabled": true
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "quantity",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Add liquidity to a pool.\n\nWeight(UID): 1000 (Additional: 3 times one second)"
+          },
+          "response": []
+        },
+        {
+          "name": "Remove Liquidity (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/liquidityRemove?poolId=&type=SINGLE&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "liquidityRemove"],
+              "query": [
+                {
+                  "key": "poolId",
+                  "value": ""
+                },
+                {
+                  "key": "type",
+                  "value": "SINGLE",
+                  "description": "* `SINGLE` - for single asset removal\n* `COMBINATION` - for combination of all coins removal"
+                },
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "description": "Mandatory for single asset removal",
+                  "disabled": true
+                },
+                {
+                  "key": "shareAmount",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Remove liquidity from a pool, `type` include `SINGLE` and `COMBINATION`, asset is mandatory for single asset removal\n\nWeight(UID): 1000 (Additional: 3 times one second)"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Liquidity Operation Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/liquidityOps?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "liquidityOps"],
+              "query": [
+                {
+                  "key": "operationId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "poolId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "operation",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get liquidity operation (add/remove) records.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Request Quote (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/quote?quoteAsset=USDT&baseAsset=BUSD&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "quote"],
+              "query": [
+                {
+                  "key": "quoteAsset",
+                  "value": "USDT"
+                },
+                {
+                  "key": "baseAsset",
+                  "value": "BUSD"
+                },
+                {
+                  "key": "quoteQty",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Request a quote for swap quote asset (selling asset) for base asset (buying asset), essentially price/exchange rates.\n\nquoteQty is quantity of quote asset (to sell).\n\nPlease be noted the quote is for reference only, the actual price will change as the liquidity changes, it's recommended to swap immediate after request a quote for slippage prevention.\n\nWeight(UID): 150"
+          },
+          "response": []
+        },
+        {
+          "name": "Swap (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/swap?quoteAsset=USDT&baseAsset=BUSD&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "swap"],
+              "query": [
+                {
+                  "key": "quoteAsset",
+                  "value": "USDT"
+                },
+                {
+                  "key": "baseAsset",
+                  "value": "BUSD"
+                },
+                {
+                  "key": "quoteQty",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Swap `quoteAsset` for `baseAsset`.\n\nWeight(UID): 1000 (Additional: 3 times one second)"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Swap History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/swap?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "swap"],
+              "query": [
+                {
+                  "key": "swapId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "status",
+                  "value": "",
+                  "description": "* `0` - pending for swap\n* `1` - success\n* `2` - failed",
+                  "disabled": true
+                },
+                {
+                  "key": "quoteAsset",
+                  "value": "USDT",
+                  "disabled": true
+                },
+                {
+                  "key": "baseAsset",
+                  "value": "BUSD",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "default 3, max 100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get swap history.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Pool Configure (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/poolConfigure?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "poolConfigure"],
+              "query": [
+                {
+                  "key": "poolId",
+                  "value": "2",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 150"
+          },
+          "response": []
+        },
+        {
+          "name": "Add Liquidity Preview (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/addLiquidityPreview?poolId=2&type=SINGLE&quoteAsset=USDT&quoteQty=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "addLiquidityPreview"],
+              "query": [
+                {
+                  "key": "poolId",
+                  "value": "2"
+                },
+                {
+                  "key": "type",
+                  "value": "SINGLE",
+                  "description": "* `SINGLE` - for adding a single token\n* `COMBINATION` - for adding dual tokens"
+                },
+                {
+                  "key": "quoteAsset",
+                  "value": "USDT"
+                },
+                {
+                  "key": "quoteQty",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Calculate expected share amount for adding liquidity in single or dual token.\n\nWeight(IP): 150"
+          },
+          "response": []
+        },
+        {
+          "name": "Remove Liquidity Preview (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/removeLiquidityPreview?poolId=2&type=SINGLE&quoteAsset=USDT&shareAmount=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "removeLiquidityPreview"],
+              "query": [
+                {
+                  "key": "poolId",
+                  "value": "2"
+                },
+                {
+                  "key": "type",
+                  "value": "SINGLE",
+                  "description": "* `SINGLE` - remove and obtain a single token\n* `COMBINATION` - remove and obtain dual token"
+                },
+                {
+                  "key": "quoteAsset",
+                  "value": "USDT"
+                },
+                {
+                  "key": "shareAmount",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Calculate the expected asset amount of single token redemption or dual token redemption.\n\nWeight(IP): 150"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Unclaimed Rewards Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/unclaimedRewards?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "unclaimedRewards"],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "0",
+                  "description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get unclaimed rewards record.\n \nWeight(UID): 1000"
+          },
+          "response": []
+        },
+        {
+          "name": "Claim Rewards (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/claimRewards?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "claimRewards"],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "0",
+                  "description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Claim swap rewards or liquidity rewards\n \nWeight(UID): 1000"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Claimed History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bswap/claimedHistory?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bswap", "claimedHistory"],
+              "query": [
+                {
+                  "key": "poolId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "assetRewards",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "type",
+                  "value": "0",
+                  "description": "0: Swap rewards, 1: Liquidity rewards, default to 0",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Default 3, max 100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get history of claimed rewards.\n \nWeight(UID): 1000"
+          },
+          "response": []
+        }
+      ],
+      "description": "Binance Swap Endpoints"
+    },
+    {
+      "name": "C2C",
+      "item": [
+        {
+          "name": "Get C2C Trade History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/c2c/orderMatch/listUserOrderHistory?tradeType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "c2c",
+                "orderMatch",
+                "listUserOrderHistory"
+              ],
+              "query": [
+                {
+                  "key": "tradeType",
+                  "value": "",
+                  "description": "BUY, SELL"
+                },
+                {
+                  "key": "startTimestamp",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTimestamp",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "rows",
+                  "value": "",
+                  "description": "default 100, max 100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If startTimestamp and endTimestamp are not sent, the recent 30-day data will be returned.\n- The max interval between startTimestamp and endTimestamp is 30 days.\n\nWeight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": "Consumer-To-Consumer Endpoints"
+    },
+    {
+      "name": "Convert",
+      "item": [
+        {
+          "name": "Get Convert Trade History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/convert/tradeFlow?startTime=&endTime=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "convert", "tradeFlow"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "default 100, max 1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 100"
+          },
+          "response": []
+        }
+      ],
+      "description": "Convert Endpoints"
+    },
+    {
+      "name": "Crypto Loans",
+      "item": [
+        {
+          "name": "Get Crypto Loans Income History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/loan/income?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "loan", "income"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "All types will be returned by default.\n* `borrowIn`\n* `collateralSpent`\n* `repayAmount`\n* `collateralReturn` - Collateral return after repayment\n* `addCollateral`\n* `removeCollateral`\n* `collateralReturnAfterLiquidation`",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "20",
+                  "description": "default 20, max 100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If startTime and endTime are not sent, the recent 7-day data will be returned.\n- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 6000"
+          },
+          "response": []
+        }
+      ],
+      "description": "Crypto Loans Endpoints"
+    },
+    {
+      "name": "Fiat",
+      "item": [
+        {
+          "name": "Get Fiat Deposit/Withdraw History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/fiat/orders?transactionType=0&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "fiat", "orders"],
+              "query": [
+                {
+                  "key": "transactionType",
+                  "value": "0",
+                  "description": "* `0` - deposit\n* `1` - withdraw"
+                },
+                {
+                  "key": "beginTime",
+                  "value": "1626144956000",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "rows",
+                  "value": "300",
+                  "description": "Default 100, max 500",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(UID): 90000"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Fiat Payments History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/fiat/payments?transactionType=0&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "fiat", "payments"],
+              "query": [
+                {
+                  "key": "transactionType",
+                  "value": "0",
+                  "description": "* `0` - deposit\n* `1` - withdraw"
+                },
+                {
+                  "key": "beginTime",
+                  "value": "1626144956000",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "rows",
+                  "value": "300",
+                  "description": "Default 100, max 500",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If beginTime and endTime are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": "Fiat Endpoints"
+    },
+    {
+      "name": "Futures",
+      "item": [
+        {
+          "name": "New Future Account Transfer (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/transfer?asset=&amount=&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "transfer"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "",
+                  "description": "The asset being transferred, e.g., USDT"
+                },
+                {
+                  "key": "amount",
+                  "value": "",
+                  "description": "The amount to be transferred"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "1: transfer from spot account to USDT-Ⓜ futures account. 2: transfer from USDT-Ⓜ futures account to spot account. 3: transfer from spot account to COIN-Ⓜ futures account. 4: transfer from COIN-Ⓜ futures account to spot account."
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Execute transfer between spot account and futures account.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Future Account Transaction History List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/transfer?asset=&startTime=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "transfer"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": ""
+                },
+                {
+                  "key": "startTime",
+                  "value": ""
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "",
+                  "description": "Currently querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Borrow For Cross-Collateral (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/borrow?coin=&collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "borrow"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "collateralAmount",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Borrow asset for Cross-Collateral."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Borrow History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/borrow/history?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "borrow", "history"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "default 500, max 1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Cross-Collateral Borrow History."
+          },
+          "response": []
+        },
+        {
+          "name": "Repay For Cross-Collateral (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/repay?coin=&collateralCoin=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "repay"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": ""
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Repay Transaction."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Repayment History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/repay/history?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "repay", "history"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "default 500, max 1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Cross-Collateral Repayment History."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Wallet (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/wallet?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "wallet"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Cross-Collateral Wallet."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Wallet V2 (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/futures/loan/wallet?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v2", "futures", "loan", "wallet"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Cross-Collateral Wallet V2."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Information (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/configs?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "configs"],
+              "query": [
+                {
+                  "key": "collateralCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Cross-Collateral Information."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Information V2 (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/futures/loan/configs?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v2", "futures", "loan", "configs"],
+              "query": [
+                {
+                  "key": "loanCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Cross-Collateral Information V2."
+          },
+          "response": []
+        },
+        {
+          "name": "Calculate Rate After Adjust Cross-Collateral LTV (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/calcAdjustLevel?collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "calcAdjustLevel"],
+              "query": [
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": ""
+                },
+                {
+                  "key": "direction",
+                  "value": "",
+                  "description": "\"ADDITIONAL\", \"REDUCED\""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Calculate Collateral Rate after adjust Cross-Collateral LTV."
+          },
+          "response": []
+        },
+        {
+          "name": "Calculate Rate After Adjust Cross-Collateral LTV V2 (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/futures/loan/calcAdjustLevel?loanCoin=&collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v2", "futures", "loan", "calcAdjustLevel"],
+              "query": [
+                {
+                  "key": "loanCoin",
+                  "value": ""
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": ""
+                },
+                {
+                  "key": "direction",
+                  "value": "",
+                  "description": "\"ADDITIONAL\", \"REDUCED\""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Calculate Collateral Rate after adjust Cross-Collateral LTV V2."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Max Amount for Adjust Cross-Collateral LTV (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/calcMaxAdjustAmount?collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "calcMaxAdjustAmount"],
+              "query": [
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Max Amount for Adjust Cross-Collateral LTV."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Max Amount for Adjust Cross-Collateral LTV V2 (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/futures/loan/calcMaxAdjustAmount?loanCoin=&collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v2", "futures", "loan", "calcMaxAdjustAmount"],
+              "query": [
+                {
+                  "key": "loanCoin",
+                  "value": ""
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Max Amount for Adjust Cross-Collateral LTV V2."
+          },
+          "response": []
+        },
+        {
+          "name": "Adjust Cross-Collateral LTV (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/adjustCollateral?collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "adjustCollateral"],
+              "query": [
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": ""
+                },
+                {
+                  "key": "direction",
+                  "value": "",
+                  "description": "\"ADDITIONAL\", \"REDUCED\""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Adjust Cross-Collateral LTV."
+          },
+          "response": []
+        },
+        {
+          "name": "Adjust Cross-Collateral LTV V2 (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/futures/loan/adjustCollateral?loanCoin=&collateralCoin=&amount=&direction=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v2", "futures", "loan", "adjustCollateral"],
+              "query": [
+                {
+                  "key": "loanCoin",
+                  "value": ""
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": ""
+                },
+                {
+                  "key": "direction",
+                  "value": "",
+                  "description": "\"ADDITIONAL\", \"REDUCED\""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Adjust Cross-Collateral LTV V2."
+          },
+          "response": []
+        },
+        {
+          "name": "Adjust Cross-Collateral LTV History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/adjustCollateral/history?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "futures",
+                "loan",
+                "adjustCollateral",
+                "history"
+              ],
+              "query": [
+                {
+                  "key": "loanCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "default 500, max 1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Adjust Cross-Collateral LTV History."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Liquidation History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/liquidationHistory?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "liquidationHistory"],
+              "query": [
+                {
+                  "key": "loanCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "default 500, max 1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get Cross-Collateral Liquidation History."
+          },
+          "response": []
+        },
+        {
+          "name": "Check Collateral Repay Limit (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/collateralRepayLimit?coin=&collateralCoin=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "collateralRepayLimit"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": ""
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Check the maximum and minimum limit when repay with collateral."
+          },
+          "response": []
+        },
+        {
+          "name": "Get Collateral Repay Quote (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/collateralRepay?coin=&collateralCoin=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "collateralRepay"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": ""
+                },
+                {
+                  "key": "collateralCoin",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": "",
+                  "description": "repay amount"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds."
+          },
+          "response": []
+        },
+        {
+          "name": "Repay with Collateral (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/collateralRepay?quoteId=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "collateralRepay"],
+              "query": [
+                {
+                  "key": "quoteId",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Repay with collateral. Get quote before repay with collateral is mandatory, the quote will be valid within 25 seconds."
+          },
+          "response": []
+        },
+        {
+          "name": "Collateral Repayment Result (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/collateralRepayResult?quoteId=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "futures",
+                "loan",
+                "collateralRepayResult"
+              ],
+              "query": [
+                {
+                  "key": "quoteId",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Check collateral repayment result."
+          },
+          "response": []
+        },
+        {
+          "name": "Cross-Collateral Interest History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/futures/loan/interestHistory?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "futures", "loan", "interestHistory"],
+              "query": [
+                {
+                  "key": "collateralCoin",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "",
+                  "description": "Currently querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Default:500 Max:1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": ""
+          },
+          "response": []
+        }
+      ],
+      "description": ""
+    },
+    {
+      "name": "Futures Algo",
+      "item": [
+        {
+          "name": "Volume Participation New Order (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/algo/futures/newOrderVp?symbol=&side=SELL&quantity=&urgency=LOW&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "algo", "futures", "newOrderVp"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "Trading symbol eg. BTCUSDT"
+                },
+                {
+                  "key": "side",
+                  "value": "SELL",
+                  "description": "Trading side ( BUY or SELL )"
+                },
+                {
+                  "key": "positionSide",
+                  "value": "",
+                  "description": "Default BOTH for One-way Mode ; LONG or SHORT for Hedge Mode. It must be sent in Hedge Mode.",
+                  "disabled": true
+                },
+                {
+                  "key": "quantity",
+                  "value": "",
+                  "description": "Quantity of base asset; The notional (quantity * mark price(base asset)) must be more than the equivalent of 10,000 USDT and less than the equivalent of 1,000,000 USDT."
+                },
+                {
+                  "key": "urgency",
+                  "value": "LOW",
+                  "description": "Represent the relative speed of the current execution; ENUM: LOW, MEDIUM, HIGH."
+                },
+                {
+                  "key": "clientAlgoId",
+                  "value": "",
+                  "description": "A unique id among Algo orders (length should be 32 characters)， If it is not sent, we will give default value.",
+                  "disabled": true
+                },
+                {
+                  "key": "reduceOnly",
+                  "value": "",
+                  "description": "\"true\" or \"false\". Default \"false\"; Cannot be sent in Hedge Mode; Cannot be sent when you open a position.",
+                  "disabled": true
+                },
+                {
+                  "key": "limitPrice",
+                  "value": "",
+                  "description": "Limit price of the order; If it is not sent, will place order by market price by default.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Send in a VP new order. Only support on USDⓈ-M Contracts.\n\nWeight(IP): 3000\n\n- Max open orders allowed: 10 orders.\n- Leverage of symbols and position mode will be the same as your futures account settings. You can set up through the trading page or fapi.\n- Receiving \"success\": true does not mean that your order will be executed. Please use the query order endpoints（GET sapi/v1/algo/futures/openOrders or GET sapi/v1/algo/futures/historicalOrders） to check the order status. For example: Your futures balance is insufficient, or open position with reduce only or position side is inconsistent with your own setting. In these cases you will receive \"success\": true, but the order status will be expired after we check it."
+          },
+          "response": []
+        },
+        {
+          "name": "Time-Weighted Average Price New Order (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/algo/futures/newOrderTwap?symbol=&side=&quantity=&duration=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "algo", "futures", "newOrderTwap"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "Trading symbol eg. BTCUSDT"
+                },
+                {
+                  "key": "side",
+                  "value": "",
+                  "description": "Trading side ( BUY or SELL )"
+                },
+                {
+                  "key": "positionSide",
+                  "value": "",
+                  "description": "Default BOTH for One-way Mode ; LONG or SHORT for Hedge Mode. It must be sent in Hedge Mode.",
+                  "disabled": true
+                },
+                {
+                  "key": "quantity",
+                  "value": "",
+                  "description": "Quantity of base asset; The notional (quantity * mark price(base asset)) must be more than the equivalent of 10,000 USDT and less than the equivalent of 1,000,000 USDT"
+                },
+                {
+                  "key": "duration",
+                  "value": "",
+                  "description": "Duration for TWAP orders in seconds. [300, 86400];Less than 5min => defaults to 5 min; Greater than 24h => defaults to 24h"
+                },
+                {
+                  "key": "clientAlgoId",
+                  "value": "",
+                  "description": "A unique id among Algo orders (length should be 32 characters)， If it is not sent, we will give default value",
+                  "disabled": true
+                },
+                {
+                  "key": "reduceOnly",
+                  "value": "",
+                  "description": "`true` or `false`. Default `false`; Cannot be sent in Hedge Mode; Cannot be sent when you open a position",
+                  "disabled": true
+                },
+                {
+                  "key": "limitPrice",
+                  "value": "",
+                  "description": "Limit price of the order; If it is not sent, will place order by market price by default",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Send in a Twap new order. Only support on USDⓈ-M Contracts.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Cancel Algo Order (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/algo/futures/order?algoId=14511&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "algo", "futures", "order"],
+              "query": [
+                {
+                  "key": "algoId",
+                  "value": "14511"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Cancel an active order.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Current Algo Open Orders (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/algo/futures/openOrders?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "algo", "futures", "openOrders"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Historical Algo Orders (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/algo/futures/historicalOrders?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "algo", "futures", "historicalOrders"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "Trading symbol eg. BTCUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "side",
+                  "value": "",
+                  "description": "BUY or SELL",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "",
+                  "description": "Default is 1",
+                  "disabled": true
+                },
+                {
+                  "key": "pageSize",
+                  "value": "",
+                  "description": "MIN 1, MAX 100; Default 100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Sub Orders (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/algo/futures/subOrders?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "algo", "futures", "subOrders"],
+              "query": [
+                {
+                  "key": "algoId",
+                  "value": "13723",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "",
+                  "description": "Default is 1",
+                  "disabled": true
+                },
+                {
+                  "key": "pageSize",
+                  "value": "",
+                  "description": "MIN 1, MAX 100; Default 100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get respective sub orders for a specified algoId\n\nWeight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": ""
+    },
+    {
+      "name": "Gift Card",
+      "item": [
+        {
+          "name": "Create a Binance Code (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/giftcard/createCode?token=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "giftcard", "createCode"],
+              "query": [
+                {
+                  "key": "token",
+                  "value": "",
+                  "description": "The coin type contained in the Binance Code"
+                },
+                {
+                  "key": "amount",
+                  "value": "",
+                  "description": "The amount of the coin"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "This API is for creating a Binance Code. To get started with, please make sure:\n\n- You have a Binance account\n- You have passed kyc\n- You have a sufﬁcient balance in your Binance funding wallet\n- You need Enable Withdrawals for the API Key which requests this endpoint.\n\nDaily creation volume: 2 BTC / 24H Daily creation times: 200 Codes / 24H\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Redeem a Binance Code (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/giftcard/redeemCode?code=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "giftcard", "redeemCode"],
+              "query": [
+                {
+                  "key": "code",
+                  "value": "",
+                  "description": "Binance Code"
+                },
+                {
+                  "key": "externalUid",
+                  "value": "",
+                  "description": "Each external unique ID represents a unique user on the partner platform. The function helps you to identify the redemption behavior of different users, such as redemption frequency and amount. It also helps risk and limit control of a single account, such as daily limit on redemption volume, frequency, and incorrect number of entries. This will also prevent a single user account reach the partner's daily redemption limits. We strongly recommend you to use this feature and transfer us the User ID of your users if you have different users redeeming Binance codes on your platform. To protect user data privacy, you may choose to transfer the user id in any desired format (max. 400 characters).",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "This API is for redeeming the Binance Code. Once redeemed, the coins will be deposited in your funding wallet.\n\nPlease note that if you enter the wrong code 5 times within 24 hours, you will no longer be able to redeem any Binance Code that day.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Verify a Binance Code (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/giftcard/verify?referenceNo=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "giftcard", "verify"],
+              "query": [
+                {
+                  "key": "referenceNo",
+                  "value": "",
+                  "description": "reference number"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "This API is for verifying whether the Binance Code is valid or not by entering Binance Code or reference number.\n\nPlease note that if you enter the wrong binance code 5 times within an hour, you will no longer be able to verify any binance code for that hour.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Fetch RSA Public Key (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/giftcard/cryptography/rsa-public-key?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "giftcard",
+                "cryptography",
+                "rsa-public-key"
+              ],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "This API is for fetching the RSA Public Key.\nThis RSA Public key will be used to encrypt the card code.\nPlease note that the RSA Public key fetched is valid only for the current day.\n\nWeight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": "Gift Card Endpoints"
+    },
+    {
+      "name": "Margin",
+      "item": [
+        {
+          "name": "Cross Margin Account Transfer (MARGIN)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/transfer?asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "transfer"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "* `1` - transfer from main account to margin account\n* `2` - transfer from margin account to main account"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Execute transfer between spot account and cross margin account.\n\nWeight(IP): 600"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Cross Margin Transfer History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/transfer?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "transfer"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "Transfer Type",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "archived",
+                  "value": "",
+                  "description": "Default: false. Set to true for archived data from 6 months ago",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Response in descending order\n- Returns data for last 7 days by default\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Account Borrow (MARGIN)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/loan?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "loan"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Apply for a loan.\n\n- If \"isIsolated\" = \"TRUE\", \"symbol\" must be sent\n- \"isIsolated\" = \"FALSE\" for crossed margin loan\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Loan Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/loan?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "loan"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "isolatedSymbol",
+                  "value": "",
+                  "description": "Isolated symbol",
+                  "disabled": true
+                },
+                {
+                  "key": "txId",
+                  "value": "123456789",
+                  "description": "the tranId in  `POST /sapi/v1/margin/loan`",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "archived",
+                  "value": "",
+                  "description": "Default: false. Set to true for archived data from 6 months ago",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- `txId` or `startTime` must be sent. `txId` takes precedence.\n- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Account Repay (MARGIN)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/repay?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "repay"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Repay loan for margin account.\n\n- If \"isIsolated\" = \"TRUE\", \"symbol\" must be sent\n- \"isIsolated\" = \"FALSE\" for crossed margin repay\n\nWeight(IP): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Repay Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/repay?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "repay"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "isolatedSymbol",
+                  "value": "",
+                  "description": "Isolated symbol",
+                  "disabled": true
+                },
+                {
+                  "key": "txId",
+                  "value": "2970933056",
+                  "description": "the tranId in  `POST /sapi/v1/margin/repay`",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "archived",
+                  "value": "",
+                  "description": "Default: false. Set to true for archived data from 6 months ago",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- `txId` or `startTime` must be sent. `txId` takes precedence.\n- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Asset (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/asset?asset=BTC",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "asset"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Cross Margin Pair (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/pair?symbol=BNBUSDT",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "pair"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Get All Margin Assets (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/allAssets",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "allAssets"]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get All Cross Margin Pairs (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/allPairs",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "allPairs"]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin PriceIndex (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/priceIndex?symbol=BNBUSDT",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "priceIndex"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Account's Order (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "order"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "orderId",
+                  "value": "",
+                  "description": "Order id",
+                  "disabled": true
+                },
+                {
+                  "key": "origClientOrderId",
+                  "value": "",
+                  "description": "Order id from client",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Either `orderId` or `origClientOrderId` must be sent.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Account New Order (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "order"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "side",
+                  "value": "SELL"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "Order type"
+                },
+                {
+                  "key": "quantity",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "quoteOrderQty",
+                  "value": "",
+                  "description": "Quote quantity",
+                  "disabled": true
+                },
+                {
+                  "key": "price",
+                  "value": "",
+                  "description": "Order price",
+                  "disabled": true
+                },
+                {
+                  "key": "stopPrice",
+                  "value": "20.01",
+                  "description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "icebergQty",
+                  "value": "",
+                  "description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
+                  "disabled": true
+                },
+                {
+                  "key": "newOrderRespType",
+                  "value": "",
+                  "description": "Set the response JSON.",
+                  "disabled": true
+                },
+                {
+                  "key": "sideEffectType",
+                  "value": "",
+                  "description": "Default `NO_SIDE_EFFECT`",
+                  "disabled": true
+                },
+                {
+                  "key": "timeInForce",
+                  "value": "",
+                  "description": "Order time in force",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Post a new order for margin account.\n\nWeight(UID): 6"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Account Cancel Order (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "order"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "orderId",
+                  "value": "",
+                  "description": "Order id",
+                  "disabled": true
+                },
+                {
+                  "key": "origClientOrderId",
+                  "value": "",
+                  "description": "Order id from client",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Cancel an active order for margin account.\n\nEither `orderId` or `origClientOrderId` must be sent.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Interest History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/interestHistory?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "interestHistory"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "isolatedSymbol",
+                  "value": "",
+                  "description": "Isolated symbol",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "archived",
+                  "value": "",
+                  "description": "Default: false. Set to true for archived data from 6 months ago",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Response in descending order\n- If `isolatedSymbol` is not sent, crossed margin data will be returned\n- Set `archived` to `true` to query data from 6 months ago\n- `type` in response has 4 enums:\n  - `PERIODIC` interest charged per hour\n  - `ON_BORROW` first interest charged on borrow\n  - `PERIODIC_CONVERTED` interest charged per hour converted into BNB\n  - `ON_BORROW_CONVERTED` first interest charged on borrow converted into BNB\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Force Liquidation Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/forceLiquidationRec?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "forceLiquidationRec"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "isolatedSymbol",
+                  "value": "",
+                  "description": "Isolated symbol",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Response in descending order\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Cross Margin Account Details (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/account?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "account"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Account's Open Orders (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/openOrders?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "openOrders"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If the `symbol` is not sent, orders for all symbols will be returned in an array.\n- When all symbols are returned, the number of requests counted against the rate limiter is equal to the number of symbols currently trading on the exchange\n- If isIsolated =\"TRUE\", symbol must be sent.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Account Cancel all Open Orders on a Symbol (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/openOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "openOrders"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Cancels all active orders on a symbol for margin account.\n- This includes OCO orders.\n\nWeight(IP): 1\n"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Account's All Orders (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/allOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "allOrders"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "orderId",
+                  "value": "",
+                  "description": "Order id",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If `orderId` is set, it will get orders >= that orderId. Otherwise most recent orders are returned.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 200\n\nRequest Limit: 60 times/min per IP"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Account New OCO (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/order/oco?symbol=BNBUSDT&side=SELL&quantity=&price=&stopPrice=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "order", "oco"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "listClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the entire orderList",
+                  "disabled": true
+                },
+                {
+                  "key": "side",
+                  "value": "SELL"
+                },
+                {
+                  "key": "quantity",
+                  "value": ""
+                },
+                {
+                  "key": "limitClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the limit order",
+                  "disabled": true
+                },
+                {
+                  "key": "price",
+                  "value": "",
+                  "description": "Order price"
+                },
+                {
+                  "key": "limitIcebergQty",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "stopClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the stop loss/stop loss limit leg",
+                  "disabled": true
+                },
+                {
+                  "key": "stopPrice",
+                  "value": ""
+                },
+                {
+                  "key": "stopLimitPrice",
+                  "value": "",
+                  "description": "If provided, stopLimitTimeInForce is required.",
+                  "disabled": true
+                },
+                {
+                  "key": "stopIcebergQty",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "stopLimitTimeInForce",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "newOrderRespType",
+                  "value": "",
+                  "description": "Set the response JSON.",
+                  "disabled": true
+                },
+                {
+                  "key": "sideEffectType",
+                  "value": "",
+                  "description": "Default `NO_SIDE_EFFECT`",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Send in a new OCO for a margin account\n\n- Price Restrictions:\n  - SELL: Limit Price > Last Price > Stop Price\n  - BUY: Limit Price < Last Price < Stop Price\n- Quantity Restrictions:\n  - Both legs must have the same quantity\n  - ICEBERG quantities however do not have to be the same.\n- Order Rate Limit\n  - OCO counts as 2 orders against the order rate limit.\n\nWeight(UID): 6"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Account's OCO (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/orderList?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "orderList"],
+              "query": [
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "Mandatory for isolated margin, not supported for cross margin",
+                  "disabled": true
+                },
+                {
+                  "key": "orderListId",
+                  "value": "",
+                  "description": "Order list id",
+                  "disabled": true
+                },
+                {
+                  "key": "origClientOrderId",
+                  "value": "",
+                  "description": "Order id from client",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Retrieves a specific OCO based on provided optional parameters\n\n- Either `orderListId` or `origClientOrderId` must be provided\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Account Cancel OCO (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/orderList?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "orderList"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "orderListId",
+                  "value": "",
+                  "description": "Order list id",
+                  "disabled": true
+                },
+                {
+                  "key": "listClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the entire orderList",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Cancel an entire Order List for a margin account\n\n- Canceling an individual leg will cancel the entire OCO\n- Either `orderListId` or `listClientOrderId` must be provided\n\nWeight(UID): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Account's all OCO (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/allOrderList?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "allOrderList"],
+              "query": [
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "Mandatory for isolated margin, not supported for cross margin",
+                  "disabled": true
+                },
+                {
+                  "key": "fromId",
+                  "value": "",
+                  "description": "If supplied, neither `startTime` or `endTime` can be provided",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Default Value: 500; Max Value: 1000",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Retrieves all OCO for a specific margin account based on provided optional parameters\n\nWeight(IP): 200"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Account's Open OCO (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/openOrderList?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "openOrderList"],
+              "query": [
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "Mandatory for isolated margin, not supported for cross margin",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Account's Trade List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/myTrades?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "myTrades"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "fromId",
+                  "value": "",
+                  "description": "Trade id to fetch from. Default gets most recent trades.",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If `fromId` is set, it will get orders >= that `fromId`. Otherwise most recent trades are returned.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Max Borrow (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/maxBorrowable?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "maxBorrowable"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "isolatedSymbol",
+                  "value": "",
+                  "description": "Isolated symbol",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If `isolatedSymbol` is not sent, crossed margin data will be sent.\n- `borrowLimit` is also available from https://www.binance.com/en/margin-fee\n\nWeight(IP): 50"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Max Transfer-Out Amount (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/maxTransferable?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "maxTransferable"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "isolatedSymbol",
+                  "value": "",
+                  "description": "Isolated symbol",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If `isolatedSymbol` is not sent, crossed margin data will be sent.\n\nWeight(IP): 50"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Isolated Margin Transfer History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/transfer?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "transfer"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "transFrom",
+                  "value": "SPOT",
+                  "disabled": true
+                },
+                {
+                  "key": "transTo",
+                  "value": "ISOLATED_MARGIN",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "archived",
+                  "value": "",
+                  "description": "Default: false. Set to true for archived data from 6 months ago",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Isolated Margin Account Transfer (MARGIN)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/transfer?asset=BTC&symbol=BNBUSDT&transFrom=SPOT&transTo=ISOLATED_MARGIN&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "transfer"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "transFrom",
+                  "value": "SPOT"
+                },
+                {
+                  "key": "transTo",
+                  "value": "ISOLATED_MARGIN"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(UID): 600"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Isolated Margin Account Info (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/account?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "account"],
+              "query": [
+                {
+                  "key": "symbols",
+                  "value": "BTCUSDT,BNBUSDT,ADAUSDT",
+                  "description": "Max 5 symbols can be sent; separated by ','",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If \"symbols\" is not sent, all isolated assets will be returned.\n- If \"symbols\" is sent, only the isolated assets of the sent symbols will be returned.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Disable Isolated Margin Account (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "account"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Disable isolated margin account for a specific symbol. Each trading pair can only be deactivated once every 24 hours .\n\nWeight(UID): 300"
+          },
+          "response": []
+        },
+        {
+          "name": "Enable Isolated Margin Account (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/account?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "account"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Enable isolated margin account for a specific symbol.\n\nWeight(UID): 300"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Enabled Isolated Margin Account Limit (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/accountLimit?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "accountLimit"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Query enabled isolated margin account limit.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Isolated Margin Symbol (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/pair?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "pair"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Get All Isolated Margin Symbol (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolated/allPairs?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolated", "allPairs"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Toggle BNB Burn On Spot Trade And Margin Interest (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bnbBurn?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bnbBurn"],
+              "query": [
+                {
+                  "key": "spotBNBBurn",
+                  "value": "true",
+                  "description": "Determines whether to use BNB to pay for trading fees on SPOT",
+                  "disabled": true
+                },
+                {
+                  "key": "interestBNBBurn",
+                  "value": "false",
+                  "description": "Determines whether to use BNB to pay for margin loan's interest",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- \"spotBNBBurn\" and \"interestBNBBurn\" should be sent at least one.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get BNB Burn Status (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/bnbBurn?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "bnbBurn"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Margin Interest Rate History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/interestRateHistory?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "interestRateHistory"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "vipLevel",
+                  "value": "",
+                  "description": "Defaults to user's vip level",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "The max interval between startTime and endTime is 30 days.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Cross Margin Fee Data (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/crossMarginData?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "crossMarginData"],
+              "query": [
+                {
+                  "key": "vipLevel",
+                  "value": "",
+                  "description": "Defaults to user's vip level",
+                  "disabled": true
+                },
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get cross margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee\n\nWeight(IP): 1 when coin is specified; 5 when the coin parameter is omitted"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Isolated Margin Fee Data (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolatedMarginData?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolatedMarginData"],
+              "query": [
+                {
+                  "key": "vipLevel",
+                  "value": "",
+                  "description": "Defaults to user's vip level",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get isolated margin fee data collection with any vip level or user's current specific data as https://www.binance.com/en/margin-fee\n\nWeight(IP): 1 when a single is specified; 10 when the symbol parameter is omitted"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Isolated Margin Tier Data (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/isolatedMarginTier?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "isolatedMarginTier"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "tier",
+                  "value": "1",
+                  "description": "All margin tier data will be returned if tier is omitted",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get isolated margin tier data collection with any tier as https://www.binance.com/en/margin-data\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Current Margin Order Count Usage (TRADE)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/rateLimit/order?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "rateLimit", "order"],
+              "query": [
+                {
+                  "key": "isIsolated",
+                  "value": "",
+                  "description": "* `TRUE` - For isolated margin\n* `FALSE` - Default, not for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "isolated symbol, mandatory for isolated margin",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Displays the user's current margin order count usage for all intervals.\n\nWeight(IP): 20"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Dustlog (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/margin/dribblet?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "margin", "dribblet"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Query the historical information of user's margin account small-value asset conversion BNB.\n\nWeight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": "Margin Account/Trade"
+    },
+    {
+      "name": "Market",
+      "item": [
+        {
+          "name": "Test Connectivity",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/ping",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "ping"]
+            },
+            "description": "Test connectivity to the Rest API.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Check Server Time",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/time",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "time"]
+            },
+            "description": "Test connectivity to the Rest API and get the current server time.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Exchange Information",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/exchangeInfo",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "exchangeInfo"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "symbols",
+                  "value": "[\"BTCUSDT\",\"BNBBTC\"]",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Current exchange trading rules and symbol information\n\n- If any symbol provided in either symbol or symbols do not exist, the endpoint will throw an error.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Order Book",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/depth?symbol=BNBUSDT",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "depth"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "If limit > 5000, then the response will truncate to 5000",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "| Limit               | Weight(IP)  |\n|---------------------|-------------|\n| 1-100               | 1           |\n| 101-500             | 5           |\n| 501-1000            | 10          |\n| 1001-5000           | 50          |"
+          },
+          "response": []
+        },
+        {
+          "name": "Recent Trades List",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/trades?symbol=BNBUSDT",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "trades"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get recent trades.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Old Trade Lookup (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/historicalTrades?symbol=BNBUSDT",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "historicalTrades"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "fromId",
+                  "value": "",
+                  "description": "Trade id to fetch from. Default gets most recent trades.",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get older market trades.\n\nWeight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Compressed/Aggregate Trades List",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/aggTrades?symbol=BNBUSDT",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "aggTrades"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "fromId",
+                  "value": "",
+                  "description": "Trade id to fetch from. Default gets most recent trades.",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Get compressed, aggregate trades. Trades that fill at the time, from the same order, with the same price will have the quantity aggregated.\n- If `startTime` and `endTime` are sent, time between startTime and endTime must be less than 1 hour.\n- If `fromId`, `startTime`, and `endTime` are not sent, the most recent aggregate trades will be returned.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Kline/Candlestick Data",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/klines?symbol=BNBUSDT&interval=",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "klines"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "interval",
+                  "value": "",
+                  "description": "kline intervals"
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Kline/candlestick bars for a symbol.\nKlines are uniquely identified by their open time.\n\n- If `startTime` and `endTime` are not sent, the most recent klines are returned.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Current Average Price",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/avgPrice?symbol=BNBUSDT",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "avgPrice"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                }
+              ]
+            },
+            "description": "Current average price for a symbol.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "24hr Ticker Price Change Statistics",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/ticker/24hr",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "ticker", "24hr"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "symbols",
+                  "value": "",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "24 hour rolling window price change statistics. Careful when accessing this with no symbol.\n\n- If the symbol is not sent, tickers for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `40` when the symbol parameter is omitted;"
+          },
+          "response": []
+        },
+        {
+          "name": "Symbol Price Ticker",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/ticker/price",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "ticker", "price"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "symbols",
+                  "value": "",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Latest price for a symbol or symbols.\n\n- If the symbol is not sent, prices for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `2` when the symbol parameter is omitted;"
+          },
+          "response": []
+        },
+        {
+          "name": "Symbol Order Book Ticker",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/ticker/bookTicker",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "ticker", "bookTicker"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "symbols",
+                  "value": "",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "Best price/qty on the order book for a symbol or symbols.\n\n- If the symbol is not sent, bookTickers for all symbols will be returned in an array.\n\nWeight(IP):\n- `1` for a single symbol;\n- `2` when the symbol parameter is omitted;"
+          },
+          "response": []
+        },
+        {
+          "name": "Rolling window price change statistics",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/ticker",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "ticker"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "symbols",
+                  "value": "",
+                  "description": "Either symbol or symbols must be provided\nExamples of accepted format for the symbols parameter: [\"BTCUSDT\",\"BNBUSDT\"] or %5B%22BTCUSDT%22,%22BNBUSDT%22%5D.\n\nThe maximum number of symbols allowed in a request is 100.",
+                  "disabled": true
+                },
+                {
+                  "key": "windowSize",
+                  "value": "",
+                  "description": "Defaults to 1d if no parameter provided.\nSupported windowSize values:\n1m,2m....59m for minutes\n1h, 2h....23h - for hours\n1d...7d - for days.\n\nUnits cannot be combined (e.g. 1d2h is not allowed)",
+                  "disabled": true
+                }
+              ]
+            },
+            "description": "The window used to compute statistics is typically slightly wider than requested windowSize.\n\nopenTime for /api/v3/ticker always starts on a minute, while the closeTime is the current time of the request. As such, the effective window might be up to 1 minute wider than requested.\n\nE.g. If the closeTime is 1641287867099 (January 04, 2022 09:17:47:099 UTC) , and the windowSize is 1d. the openTime will be: 1641201420000 (January 3, 2022, 09:17:00 UTC)\n\nWeight(IP): 2 for each requested symbol regardless of windowSize.\n\nThe weight for this request will cap at 100 once the number of symbols in the request is more than 50."
+          },
+          "response": []
+        }
+      ],
+      "description": "Market Data"
+    },
+    {
+      "name": "Mining",
+      "item": [
+        {
+          "name": "Acquiring Algorithm (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/pub/algoList",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "pub", "algoList"]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Acquiring CoinName (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/pub/coinList",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "pub", "coinList"]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Request for Detail Miner List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/worker/detail?algo=&userName=&workerName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "worker", "detail"],
+              "query": [
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "workerName",
+                  "value": "",
+                  "description": "Miner’s name"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Request for Miner List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/worker/list?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "worker", "list"],
+              "query": [
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "pageIndex",
+                  "value": "",
+                  "description": "Page number, default is first page, start form 1",
+                  "disabled": true
+                },
+                {
+                  "key": "sort",
+                  "value": "",
+                  "description": "sort sequence（default=0）0 positive sequence, 1 negative sequence",
+                  "disabled": true
+                },
+                {
+                  "key": "sortColumn",
+                  "value": "",
+                  "description": "Sort by( default 1): 1: miner name, 2: real-time computing power, 3: daily average computing power, 4: real-time rejection rate, 5: last submission time",
+                  "disabled": true
+                },
+                {
+                  "key": "workerStatus",
+                  "value": "",
+                  "description": "miners status（default=0）0 all, 1 valid, 2 invalid, 3 failure",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Earnings List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/payment/list?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "payment", "list"],
+              "query": [
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name",
+                  "disabled": true
+                },
+                {
+                  "key": "startDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "endDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "pageIndex",
+                  "value": "",
+                  "description": "Page number, default is first page, start form 1",
+                  "disabled": true
+                },
+                {
+                  "key": "pageSize",
+                  "value": "",
+                  "description": "Number of pages, minimum 10, maximum 200",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Extra Bonus List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/payment/other?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "payment", "other"],
+              "query": [
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name",
+                  "disabled": true
+                },
+                {
+                  "key": "startDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "endDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "pageIndex",
+                  "value": "",
+                  "description": "Page number, default is first page, start form 1",
+                  "disabled": true
+                },
+                {
+                  "key": "pageSize",
+                  "value": "",
+                  "description": "Number of pages, minimum 10, maximum 200",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Hashrate Resale List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/hash-transfer/config/details/list?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "mining",
+                "hash-transfer",
+                "config",
+                "details",
+                "list"
+              ],
+              "query": [
+                {
+                  "key": "pageIndex",
+                  "value": "",
+                  "description": "Page number, default is first page, start form 1",
+                  "disabled": true
+                },
+                {
+                  "key": "pageSize",
+                  "value": "",
+                  "description": "Number of pages, minimum 10, maximum 200",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Hashrate Resale Detail (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/hash-transfer/profit/details?configId=&userName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "mining",
+                "hash-transfer",
+                "profit",
+                "details"
+              ],
+              "query": [
+                {
+                  "key": "configId",
+                  "value": "",
+                  "description": "Mining ID"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "pageIndex",
+                  "value": "",
+                  "description": "Page number, default is first page, start form 1",
+                  "disabled": true
+                },
+                {
+                  "key": "pageSize",
+                  "value": "",
+                  "description": "Number of pages, minimum 10, maximum 200",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Hashrate Resale Request (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/hash-transfer/config?userName=&algo=&toPoolUser=&hashRate=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "hash-transfer", "config"],
+              "query": [
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "startDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "endDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "toPoolUser",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "hashRate",
+                  "value": "",
+                  "description": "Resale hashrate h/s must be transferred (BTC is greater than 500000000000 ETH is greater than 500000)"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Cancel hashrate resale configuration (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/hash-transfer/config/cancel?configId=&userName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "mining",
+                "hash-transfer",
+                "config",
+                "cancel"
+              ],
+              "query": [
+                {
+                  "key": "configId",
+                  "value": "",
+                  "description": "Mining ID"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Statistic List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/statistics/user/status?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "statistics", "user", "status"],
+              "query": [
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Account List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/statistics/user/list?algo=&userName=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "statistics", "user", "list"],
+              "query": [
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "userName",
+                  "value": "",
+                  "description": "Mining Account"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Mining Account Earning (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/mining/payment/uid?algo=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "mining", "payment", "uid"],
+              "query": [
+                {
+                  "key": "algo",
+                  "value": "",
+                  "description": "Algorithm(sha256)"
+                },
+                {
+                  "key": "startDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "endDate",
+                  "value": "",
+                  "description": "Search date, millisecond timestamp, while empty query all",
+                  "disabled": true
+                },
+                {
+                  "key": "pageIndex",
+                  "value": "",
+                  "description": "Page number, default is first page, start form 1",
+                  "disabled": true
+                },
+                {
+                  "key": "pageSize",
+                  "value": "",
+                  "description": "Number of pages, minimum 10, maximum 200",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 5"
+          },
+          "response": []
+        }
+      ],
+      "description": "Mining Endpoints"
+    },
+    {
+      "name": "NFT",
+      "item": [
+        {
+          "name": "Get NFT Transaction History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/nft/history/transactions?orderType=1&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "nft", "history", "transactions"],
+              "query": [
+                {
+                  "key": "orderType",
+                  "value": "1",
+                  "description": "0: purchase order, 1: sell order, 2: royalty income, 3: primary market order, 4: mint fee"
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Default 50, Max 50",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Get NFT Deposit History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/nft/history/deposit?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "nft", "history", "deposit"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Default 50, Max 50",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Get NFT Withdraw History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/nft/history/withdraw?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "nft", "history", "withdraw"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Default 50, Max 50",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Get NFT Asset (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/nft/user/getAsset?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "nft", "user", "getAsset"],
+              "query": [
+                {
+                  "key": "limit",
+                  "value": "50",
+                  "description": "Default 50, Max 50",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(UID): 3000"
+          },
+          "response": []
+        }
+      ],
+      "description": "NFT Endpoints"
+    },
+    {
+      "name": "Pay",
+      "item": [
+        {
+          "name": "Get Pay Trade History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/pay/transactions?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "pay", "transactions"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "100",
+                  "description": "default 100, max 100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If startTimestamp and endTimestamp are not sent, the recent 90 days' data will be returned.\n- The max interval between startTimestamp and endTimestamp is 90 days.\n- Support for querying orders within the last 18 months.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        }
+      ],
+      "description": "Pay Endpoints"
+    },
+    {
+      "name": "Portfolio Margin",
+      "item": [
+        {
+          "name": "Get Portfolio Margin Account Info (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/portfolio/account?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "portfolio", "account"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Portfolio Margin Collateral Rate (MARKET_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/portfolio/collateralRate",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "portfolio", "collateralRate"]
+            },
+            "description": "Portfolio Margin Collateral Rate.\n\nWeight(IP): 50"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Portfolio Margin Bankruptcy Loan Amount (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/portfolio/pmLoan?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "portfolio", "pmLoan"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Query Portfolio Margin Bankruptcy Loan Amount.\n\nWeight(UID): 500"
+          },
+          "response": []
+        },
+        {
+          "name": "Portfolio Margin Bankruptcy Loan Repay (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/portfolio/repay?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "portfolio", "repay"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Repay Portfolio Margin Bankruptcy Loan.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        }
+      ],
+      "description": "The Binance Portfolio Margin Program is a cross-asset margin program supporting consolidated margin balance across trading products with over 200+ effective crypto collaterals. It is designed for professional traders, market makers, and institutional users looking to actively trade & hedge cross-asset and optimize risk-management in a consolidated setup."
+    },
+    {
+      "name": "Rebate",
+      "item": [
+        {
+          "name": "Get Spot Rebate History Records (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/rebate/taxQuery?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "rebate", "taxQuery"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The max interval between startTime and endTime is 90 days.\n- If startTime and endTime are not sent, the recent 7 days' data will be returned.\n- The earliest startTime is supported on June 10, 2020\n\nWeight(UID): 3000"
+          },
+          "response": []
+        }
+      ],
+      "description": "Rebate Endpoints"
+    },
+    {
+      "name": "Savings",
+      "item": [
+        {
+          "name": "Get Flexible Product List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/daily/product/list?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "daily", "product", "list"],
+              "query": [
+                {
+                  "key": "status",
+                  "value": "",
+                  "description": "Default `ALL`",
+                  "disabled": true
+                },
+                {
+                  "key": "featured",
+                  "value": "",
+                  "description": "Default `ALL`",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Left Daily Purchase Quota of Flexible Product (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/daily/userLeftQuota?productId=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "daily", "userLeftQuota"],
+              "query": [
+                {
+                  "key": "productId",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Purchase Flexible Product (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/daily/purchase?productId=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "daily", "purchase"],
+              "query": [
+                {
+                  "key": "productId",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Left Daily Redemption Quota of Flexible Product (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/daily/userRedemptionQuota?productId=&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "daily", "userRedemptionQuota"],
+              "query": [
+                {
+                  "key": "productId",
+                  "value": ""
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "\"FAST\", \"NORMAL\""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Redeem Flexible Product (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/daily/redeem?productId=&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "daily", "redeem"],
+              "query": [
+                {
+                  "key": "productId",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "\"FAST\", \"NORMAL\""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Flexible Product Position (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/daily/token/position?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "daily", "token", "position"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Fixed and Activity Project List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/project/list?type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "project", "list"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "\"ACTIVITY\", \"CUSTOMIZED_FIXED\""
+                },
+                {
+                  "key": "status",
+                  "value": "",
+                  "description": "Default `ALL`",
+                  "disabled": true
+                },
+                {
+                  "key": "isSortAsc",
+                  "value": "",
+                  "description": "default \"true\"",
+                  "disabled": true
+                },
+                {
+                  "key": "sortBy",
+                  "value": "",
+                  "description": "Default `START_TIME`",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Purchase Fixed/Activity Project (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/customizedFixed/purchase?projectId=&lot=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "customizedFixed", "purchase"],
+              "query": [
+                {
+                  "key": "projectId",
+                  "value": ""
+                },
+                {
+                  "key": "lot",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Fixed/Activity Project Position (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/project/position/list?asset=BTC&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "project", "position", "list"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "projectId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "status",
+                  "value": "",
+                  "description": "Default `ALL`",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Lending Account (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/union/account?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "union", "account"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Purchase Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/union/purchaseRecord?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "union", "purchaseRecord"],
+              "query": [
+                {
+                  "key": "lendingType",
+                  "value": "",
+                  "description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
+                },
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeigh(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Redemption Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/union/redemptionRecord?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "union", "redemptionRecord"],
+              "query": [
+                {
+                  "key": "lendingType",
+                  "value": "",
+                  "description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
+                },
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Interest History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/union/interestHistory?lendingType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "union", "interestHistory"],
+              "query": [
+                {
+                  "key": "lendingType",
+                  "value": "",
+                  "description": "* `DAILY` - for flexible\n* `ACTIVITY` - for activity\n* `CUSTOMIZED_FIXED` for fixed"
+                },
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The time between startTime and endTime cannot be longer than 30 days.\n- If startTime and endTime are both not sent, then the last 30 days' data will be returned.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Change Fixed/Activity Position to Daily Position (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/lending/positionChanged?projectId=&lot=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "lending", "positionChanged"],
+              "query": [
+                {
+                  "key": "projectId",
+                  "value": ""
+                },
+                {
+                  "key": "lot",
+                  "value": ""
+                },
+                {
+                  "key": "positionId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- PositionId is mandatory parameter for fixed position.\n\nWeight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": "Savings Endpoints"
+    },
+    {
+      "name": "Staking",
+      "item": [
+        {
+          "name": "Get Staking Product List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/staking/productList?product=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "staking", "productList"],
+              "query": [
+                {
+                  "key": "product",
+                  "value": "",
+                  "description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
+                },
+                {
+                  "key": "asset",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "",
+                  "description": "Currently querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "",
+                  "description": "Default:10, Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get available Staking product list.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Purchase Staking Product (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/staking/purchase?product=&productId=&amount=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "staking", "purchase"],
+              "query": [
+                {
+                  "key": "product",
+                  "value": "",
+                  "description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
+                },
+                {
+                  "key": "productId",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": ""
+                },
+                {
+                  "key": "renewable",
+                  "value": "",
+                  "description": "true or false, default false. Active if product is `STAKING` or `L_DEFI`",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Redeem Staking Product (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/staking/redeem?product=&productId=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "staking", "redeem"],
+              "query": [
+                {
+                  "key": "product",
+                  "value": "",
+                  "description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
+                },
+                {
+                  "key": "positionId",
+                  "value": "",
+                  "description": "Mandatory if product is `STAKING` or `L_DEFI`",
+                  "disabled": true
+                },
+                {
+                  "key": "productId",
+                  "value": ""
+                },
+                {
+                  "key": "amount",
+                  "value": "",
+                  "description": "Mandatory if product is `F_DEFI`",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Redeem Staking product. Locked staking and Locked DeFI staking belong to early redemption, redeeming in advance will result in loss of interest that you have earned.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Staking Product Position (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/staking/position?product=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "staking", "position"],
+              "query": [
+                {
+                  "key": "product",
+                  "value": "",
+                  "description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
+                },
+                {
+                  "key": "productId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "asset",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "",
+                  "description": "Currently querying the page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "",
+                  "description": "Default:10, Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Staking History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/staking/stakingRecord?product=&txnType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "staking", "stakingRecord"],
+              "query": [
+                {
+                  "key": "product",
+                  "value": "",
+                  "description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
+                },
+                {
+                  "key": "txnType",
+                  "value": "",
+                  "description": "`SUBSCRIPTION`, `REDEMPTION`, `INTEREST`"
+                },
+                {
+                  "key": "asset",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "",
+                  "description": "Currently querying the page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "",
+                  "description": "Default:10, Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Set Auto Staking (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/staking/setAutoStaking?product=&positionId=&renewable=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "staking", "setAutoStaking"],
+              "query": [
+                {
+                  "key": "product",
+                  "value": "",
+                  "description": "* `STAKING` - for Locked Staking\n* `L_DEFI` - for locked DeFi Staking"
+                },
+                {
+                  "key": "positionId",
+                  "value": ""
+                },
+                {
+                  "key": "renewable",
+                  "value": "",
+                  "description": "true or false"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Set auto staking on Locked Staking or Locked DeFi Staking\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Personal Left Quota of Staking Product (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/staking/personalLeftQuota?product=&productId=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "staking", "personalLeftQuota"],
+              "query": [
+                {
+                  "key": "product",
+                  "value": "",
+                  "description": "* `STAKING` - for Locked Staking\n* `F_DEFI` - for flexible DeFi Staking\n* `L_DEFI` - for locked DeFi Staking"
+                },
+                {
+                  "key": "productId",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": ""
+    },
+    {
+      "name": "Sub-Account",
+      "item": [
+        {
+          "name": "Create a Virtual Sub-account (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/virtualSubAccount?subAccountString=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "virtualSubAccount"],
+              "query": [
+                {
+                  "key": "subAccountString",
+                  "value": "",
+                  "description": "Please input a string. We will create a virtual email using that string for you to register"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- This request will generate a virtual sub account under your master account.\n- You need to enable \"trade\" option for the api key which requests this endpoint.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Sub-account List (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/list?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "list"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "isFreeze",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "1",
+                  "description": "Default 1; max 200",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Sub-account Spot Asset Transfer History (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/sub/transfer/history?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "sub",
+                "transfer",
+                "history"
+              ],
+              "query": [
+                {
+                  "key": "fromEmail",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "toEmail",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- fromEmail and toEmail cannot be sent at the same time.\n- Return fromEmail equal master account email by default.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Sub-account Futures Asset Transfer History (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?email=&futuresType=2&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "futures",
+                "internalTransfer"
+              ],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "futuresType",
+                  "value": "2",
+                  "description": "1:USDT-margined Futures, 2: Coin-margined Futures"
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Default value: 50, Max value: 500",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Sub-account Futures Asset Transfer (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/futures/internalTransfer?fromEmail=&toEmail=&futuresType=2&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "futures",
+                "internalTransfer"
+              ],
+              "query": [
+                {
+                  "key": "fromEmail",
+                  "value": "",
+                  "description": "Sender email"
+                },
+                {
+                  "key": "toEmail",
+                  "value": "",
+                  "description": "Recipient email"
+                },
+                {
+                  "key": "futuresType",
+                  "value": "2",
+                  "description": "1:USDT-margined Futures,2: Coin-margined Futures"
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Master account can transfer max 2000 times a minute\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Sub-account Assets (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v3/sub-account/assets?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v3", "sub-account", "assets"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch sub-account assets\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Sub-account Spot Assets Summary (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/spotSummary?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "spotSummary"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "",
+                  "description": "Default:10 Max:20",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get BTC valued asset summary of subaccounts.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Sub-account Deposit Address (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/capital/deposit/subAddress?email=&coin=BNB&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "capital", "deposit", "subAddress"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name"
+                },
+                {
+                  "key": "network",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch sub-account deposit address\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Sub-account Deposit History (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/capital/deposit/subHisrec?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "capital", "deposit", "subHisrec"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name",
+                  "disabled": true
+                },
+                {
+                  "key": "status",
+                  "value": "",
+                  "description": "0(0:pending,6: credited but cannot withdraw, 1:success)",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch sub-account deposit history\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Sub-account's Status on Margin/Futures (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/status?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "status"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If no `email` sent, all sub-accounts' information will be returned.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Enable Margin for Sub-account (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/margin/enable?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "margin", "enable"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Detail on Sub-account's Margin Account (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/margin/account?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "margin", "account"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Summary of Sub-account's Margin Account (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/margin/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "margin", "accountSummary"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Enable Futures for Sub-account (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/futures/enable?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "futures", "enable"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Detail on Sub-account's Futures Account (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/futures/account?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "futures", "account"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Summary of Sub-account's Futures Account (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/futures/accountSummary?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "futures",
+                "accountSummary"
+              ],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Futures Position-Risk of Sub-account (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/futures/positionRisk?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "futures", "positionRisk"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Futures Transfer for Sub-account (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/futures/transfer?email=&asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "futures", "transfer"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "* `1` - transfer from subaccount's spot account to its USDT-margined futures account\n* `2` - transfer from subaccount's USDT-margined futures account to its spot account\n* `3` - transfer from subaccount's spot account to its COIN-margined futures account\n* `4` - transfer from subaccount's COIN-margined futures account to its spot account"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Margin Transfer for Sub-account (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/margin/transfer?email=&asset=BTC&amount=1.01&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "margin", "transfer"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "* `1` - transfer from subaccount's spot account to margin account\n* `2` - transfer from subaccount's margin account to its spot account"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Transfer to Sub-account of Same Master (For Sub-account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/transfer/subToSub?toEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "transfer", "subToSub"],
+              "query": [
+                {
+                  "key": "toEmail",
+                  "value": "",
+                  "description": "Recipient email"
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Transfer to Master (For Sub-account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/transfer/subToMaster?asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "transfer", "subToMaster"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Sub-account Transfer History (For Sub-account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/transfer/subUserHistory?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "transfer",
+                "subUserHistory"
+              ],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "* `1` - transfer in\n* `2` - transfer out",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- If `type` is not sent, the records of type 2: transfer out will be returned by default.\n- If `startTime` and `endTime` are not sent, the recent 30-day data will be returned.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Universal Transfer History (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/universalTransfer?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "universalTransfer"],
+              "query": [
+                {
+                  "key": "fromEmail",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "toEmail",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "clientTranId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Default 500, Max 500",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- `fromEmail` and `toEmail` cannot be sent at the same time.\n- Return `fromEmail` equal master account email by default.\n- The query time period must be less then 30 days.\n- If startTime and endTime not sent, return records of the last 30 days by default.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Universal Transfer (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/universalTransfer?fromAccountType=&toAccountType=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "universalTransfer"],
+              "query": [
+                {
+                  "key": "fromEmail",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "toEmail",
+                  "value": "",
+                  "description": "Sub-account email",
+                  "disabled": true
+                },
+                {
+                  "key": "fromAccountType",
+                  "value": ""
+                },
+                {
+                  "key": "toAccountType",
+                  "value": ""
+                },
+                {
+                  "key": "clientTranId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "symbol",
+                  "value": "",
+                  "description": "Only supported under ISOLATED_MARGIN type",
+                  "disabled": true
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- You need to enable \"internal transfer\" option for the api key which requests this endpoint.\n- Transfer from master account by default if fromEmail is not sent.\n- Transfer to master account by default if toEmail is not sent.\n- Transfer between futures accounts is not supported.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Detail on Sub-account's Futures Account V2 (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/sub-account/futures/account?email=&futuresType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v2", "sub-account", "futures", "account"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "futuresType",
+                  "value": "",
+                  "description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Summary of Sub-account's Futures Account V2 (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/sub-account/futures/accountSummary?futuresType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v2",
+                "sub-account",
+                "futures",
+                "accountSummary"
+              ],
+              "query": [
+                {
+                  "key": "futuresType",
+                  "value": "",
+                  "description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
+                },
+                {
+                  "key": "page",
+                  "value": "1",
+                  "description": "Default 1",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "Default 10, Max 20",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Futures Position-Risk of Sub-account V2 (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v2/sub-account/futures/positionRisk?email=&futuresType=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v2", "sub-account", "futures", "positionRisk"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "futuresType",
+                  "value": "",
+                  "description": "* `1` - USDT Margined Futures\n* `2` - COIN Margined Futures"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Enable Leverage Token for Sub-account (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/blvt/enable?email=&enableBlvt=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "sub-account", "blvt", "enable"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "enableBlvt",
+                  "value": "",
+                  "description": "Only true for now"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Deposit assets into the managed sub-account (For Investor Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/managed-subaccount/deposit?toEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "managed-subaccount", "deposit"],
+              "query": [
+                {
+                  "key": "toEmail",
+                  "value": "",
+                  "description": "Recipient email"
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query managed sub-account asset details (For Investor Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/managed-subaccount/asset?email=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "managed-subaccount", "asset"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Withdrawl assets from the managed sub-account (For Investor Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/managed-subaccount/withdraw?fromEmail=&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "managed-subaccount", "withdraw"],
+              "query": [
+                {
+                  "key": "fromEmail",
+                  "value": "",
+                  "description": "Sender email"
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "transferDate",
+                  "value": "",
+                  "description": "Withdrawals is automatically occur on the transfer date(UTC0). If a date is not selected, the withdrawal occurs right now",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query managed sub-account snapshot (For Investor Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/managed-subaccount/accountSnapshot?email=testaccount@email.com&type=SPOT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "managed-subaccount", "accountSnapshot"],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "testaccount@email.com"
+                },
+                {
+                  "key": "type",
+                  "value": "SPOT",
+                  "description": "\"SPOT\", \"MARGIN\"（cross）, \"FUTURES\"（UM）"
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "description": "min 7, max 30, default 7",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The query time period must be less then 30 days\n- Support query within the last one month only\n- If `startTime` and `endTime` not sent, return records of the last 7 days by default\n\nWeight(IP): 2400"
+          },
+          "response": []
+        },
+        {
+          "name": "Enable or Disable IP Restriction for a Sub-account API Key (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&ipRestrict=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "subAccountApi",
+                "ipRestriction"
+              ],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "subAccountApiKey",
+                  "value": ""
+                },
+                {
+                  "key": "ipRestrict",
+                  "value": "",
+                  "description": "true or false"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Get IP Restriction for a Sub-account API Key (For Master Account)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction?email=&subAccountApiKey=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "subAccountApi",
+                "ipRestriction"
+              ],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "subAccountApiKey",
+                  "value": ""
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Add IP List for a Sub-account API Key (For Master Account)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "subAccountApi",
+                "ipRestriction",
+                "ipList"
+              ],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "subAccountApiKey",
+                  "value": ""
+                },
+                {
+                  "key": "ipAddress",
+                  "value": "",
+                  "description": "Can be added in batches, separated by commas"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Before the usage of this endpoint, please ensure `POST /sapi/v1/sub-account/subAccountApi/ipRestriction` was used to enable the IP restriction.\n\nWeight(UID): 3000"
+          },
+          "response": []
+        },
+        {
+          "name": "Delete IP List for a Sub-account API Key (For Master Account)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/sub-account/subAccountApi/ipRestriction/ipList?email=&subAccountApiKey=&ipAddress=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": [
+                "sapi",
+                "v1",
+                "sub-account",
+                "subAccountApi",
+                "ipRestriction",
+                "ipList"
+              ],
+              "query": [
+                {
+                  "key": "email",
+                  "value": "",
+                  "description": "Sub-account email"
+                },
+                {
+                  "key": "subAccountApiKey",
+                  "value": ""
+                },
+                {
+                  "key": "ipAddress",
+                  "value": "",
+                  "description": "Can be added in batches, separated by commas"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(UID): 3000"
+          },
+          "response": []
+        }
+      ],
+      "description": "Sub-account Endpoints"
+    },
+    {
+      "name": "Trade",
+      "item": [
+        {
+          "name": "Test New Order (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/order/test?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "order", "test"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "side",
+                  "value": "SELL"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "Order type"
+                },
+                {
+                  "key": "timeInForce",
+                  "value": "",
+                  "description": "Order time in force",
+                  "disabled": true
+                },
+                {
+                  "key": "quantity",
+                  "value": "",
+                  "description": "Order quantity",
+                  "disabled": true
+                },
+                {
+                  "key": "quoteOrderQty",
+                  "value": "",
+                  "description": "Quote quantity",
+                  "disabled": true
+                },
+                {
+                  "key": "price",
+                  "value": "",
+                  "description": "Order price",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "strategyId",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                },
+                {
+                  "key": "strategyType",
+                  "value": "",
+                  "description": "The value cannot be less than 1000000",
+                  "disabled": true
+                },
+                {
+                  "key": "stopPrice",
+                  "value": "20.01",
+                  "description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+                  "disabled": true
+                },
+                {
+                  "key": "trailingDelta",
+                  "value": "",
+                  "description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+                  "disabled": true
+                },
+                {
+                  "key": "icebergQty",
+                  "value": "",
+                  "description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
+                  "disabled": true
+                },
+                {
+                  "key": "newOrderRespType",
+                  "value": "",
+                  "description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Test new order creation and signature/recvWindow long.\nCreates and validates a new order but does not send it into the matching engine.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Order (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "order"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "orderId",
+                  "value": "",
+                  "description": "Order id",
+                  "disabled": true
+                },
+                {
+                  "key": "origClientOrderId",
+                  "value": "",
+                  "description": "Order id from client",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Check an order's status.\n\n- Either `orderId` or `origClientOrderId` must be sent.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n\nWeight(IP): 2"
+          },
+          "response": []
+        },
+        {
+          "name": "Cancel an Existing Order and Send a New Order (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/order/cancelReplace?symbol=BNBUSDT&side=SELL&type=&cancelReplaceMode=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "order", "cancelReplace"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "side",
+                  "value": "SELL"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "Order type"
+                },
+                {
+                  "key": "cancelReplaceMode",
+                  "value": "",
+                  "description": "- `STOP_ON_FAILURE` If the cancel request fails, the new order placement will not be attempted.\n- `ALLOW_FAILURES` If new order placement will be attempted even if cancel request fails."
+                },
+                {
+                  "key": "timeInForce",
+                  "value": "",
+                  "description": "Order time in force",
+                  "disabled": true
+                },
+                {
+                  "key": "quantity",
+                  "value": "",
+                  "description": "Order quantity",
+                  "disabled": true
+                },
+                {
+                  "key": "quoteOrderQty",
+                  "value": "",
+                  "description": "Quote quantity",
+                  "disabled": true
+                },
+                {
+                  "key": "price",
+                  "value": "",
+                  "description": "Order price",
+                  "disabled": true
+                },
+                {
+                  "key": "cancelNewClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "cancelOrigClientOrderId",
+                  "value": "",
+                  "description": "Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.",
+                  "disabled": true
+                },
+                {
+                  "key": "cancelOrderId",
+                  "value": "",
+                  "description": "Either the cancelOrigClientOrderId or cancelOrderId must be provided. If both are provided, cancelOrderId takes precedence.",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to identify the new order. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "strategyId",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                },
+                {
+                  "key": "strategyType",
+                  "value": "",
+                  "description": "The value cannot be less than 1000000",
+                  "disabled": true
+                },
+                {
+                  "key": "stopPrice",
+                  "value": "20.01",
+                  "description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+                  "disabled": true
+                },
+                {
+                  "key": "trailingDelta",
+                  "value": "",
+                  "description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+                  "disabled": true
+                },
+                {
+                  "key": "icebergQty",
+                  "value": "",
+                  "description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
+                  "disabled": true
+                },
+                {
+                  "key": "newOrderRespType",
+                  "value": "",
+                  "description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Cancels an existing order and places a new order on the same symbol.\n\nFilters are evaluated before the cancel order is placed.\n\nIf the new order placement is successfully sent to the engine, the order count will increase by 1.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "New Order (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/order?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "order"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "side",
+                  "value": "SELL"
+                },
+                {
+                  "key": "type",
+                  "value": "",
+                  "description": "Order type"
+                },
+                {
+                  "key": "timeInForce",
+                  "value": "",
+                  "description": "Order time in force",
+                  "disabled": true
+                },
+                {
+                  "key": "quantity",
+                  "value": "",
+                  "description": "Order quantity",
+                  "disabled": true
+                },
+                {
+                  "key": "quoteOrderQty",
+                  "value": "",
+                  "description": "Quote quantity",
+                  "disabled": true
+                },
+                {
+                  "key": "price",
+                  "value": "",
+                  "description": "Order price",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "strategyId",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                },
+                {
+                  "key": "strategyType",
+                  "value": "",
+                  "description": "The value cannot be less than 1000000",
+                  "disabled": true
+                },
+                {
+                  "key": "stopPrice",
+                  "value": "20.01",
+                  "description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+                  "disabled": true
+                },
+                {
+                  "key": "trailingDelta",
+                  "value": "",
+                  "description": "Used with STOP_LOSS, STOP_LOSS_LIMIT, TAKE_PROFIT, and TAKE_PROFIT_LIMIT orders.",
+                  "disabled": true
+                },
+                {
+                  "key": "icebergQty",
+                  "value": "",
+                  "description": "Used with LIMIT, STOP_LOSS_LIMIT, and TAKE_PROFIT_LIMIT to create an iceberg order.",
+                  "disabled": true
+                },
+                {
+                  "key": "newOrderRespType",
+                  "value": "",
+                  "description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Send in a new order.\n\n- `LIMIT_MAKER` are `LIMIT` orders that will be rejected if they would immediately match and trade as a taker.\n- `STOP_LOSS` and `TAKE_PROFIT` will execute a `MARKET` order when the `stopPrice` is reached.\n- Any `LIMIT` or `LIMIT_MAKER` type order can be made an iceberg order by sending an `icebergQty`.\n- Any order with an `icebergQty` MUST have `timeInForce` set to `GTC`.\n- `MARKET` orders using `quantity` specifies how much a user wants to buy or sell based on the market price.\n- `MARKET` orders using `quoteOrderQty` specifies the amount the user wants to spend (when buying) or receive (when selling) of the quote asset; the correct quantity will be determined based on the market liquidity and `quoteOrderQty`.\n- `MARKET` orders using `quoteOrderQty` will not break `LOT_SIZE` filter rules; the order will execute a quantity that will have the notional value as close as possible to `quoteOrderQty`.\n- same `newClientOrderId` can be accepted only when the previous one is filled, otherwise the order will be rejected.\n\nTrigger order price rules against market price for both `MARKET` and `LIMIT` versions:\n\n- Price above market price: `STOP_LOSS` `BUY`, `TAKE_PROFIT` `SELL`\n- Price below market price: `STOP_LOSS` `SELL`, `TAKE_PROFIT` `BUY`\n\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Cancel Order (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/order?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "order"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "orderId",
+                  "value": "",
+                  "description": "Order id",
+                  "disabled": true
+                },
+                {
+                  "key": "origClientOrderId",
+                  "value": "",
+                  "description": "Order id from client",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Cancel an active order.\n\nEither `orderId` or `origClientOrderId` must be sent.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Current Open Orders (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/openOrders?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "openOrders"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get all open orders on a symbol. Careful when accessing this with no symbol.\n\nWeight(IP):\n- `3` for a single symbol;\n- `40` when the symbol parameter is omitted;"
+          },
+          "response": []
+        },
+        {
+          "name": "Cancel all Open Orders on a Symbol (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/openOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "openOrders"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Cancels all active orders on a symbol.\nThis includes OCO orders.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "All Orders (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/allOrders?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "allOrders"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "orderId",
+                  "value": "",
+                  "description": "Order id",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get all account orders; active, canceled, or filled..\n\n- If `orderId` is set, it will get orders >= that `orderId`. Otherwise most recent orders are returned.\n- For some historical orders `cummulativeQuoteQty` will be < 0, meaning the data is not available at this time.\n- If `startTime` and/or `endTime` provided, `orderId` is not required\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "New OCO (TRADE)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/order/oco?symbol=BNBUSDT&side=SELL&quantity=&price=&stopPrice=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "order", "oco"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "listClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the entire orderList",
+                  "disabled": true
+                },
+                {
+                  "key": "side",
+                  "value": "SELL"
+                },
+                {
+                  "key": "quantity",
+                  "value": ""
+                },
+                {
+                  "key": "limitClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the limit order",
+                  "disabled": true
+                },
+                {
+                  "key": "limitStrategyId",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limitStrategyType",
+                  "value": "",
+                  "description": "The value cannot be less than 1000000",
+                  "disabled": true
+                },
+                {
+                  "key": "price",
+                  "value": "",
+                  "description": "Order price"
+                },
+                {
+                  "key": "limitIcebergQty",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "trailingDelta",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "stopClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the stop loss/stop loss limit leg",
+                  "disabled": true
+                },
+                {
+                  "key": "stopPrice",
+                  "value": ""
+                },
+                {
+                  "key": "stopStrategyId",
+                  "value": "",
+                  "description": "",
+                  "disabled": true
+                },
+                {
+                  "key": "stopStrategyType",
+                  "value": "",
+                  "description": "The value cannot be less than 1000000",
+                  "disabled": true
+                },
+                {
+                  "key": "stopLimitPrice",
+                  "value": "",
+                  "description": "If provided, stopLimitTimeInForce is required.",
+                  "disabled": true
+                },
+                {
+                  "key": "stopIcebergQty",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "stopLimitTimeInForce",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "newOrderRespType",
+                  "value": "",
+                  "description": "Set the response JSON.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Send in a new OCO\n\n- Price Restrictions:\n  - `SELL`: Limit Price > Last Price > Stop Price\n  - `BUY`: Limit Price < Last Price < Stop Price\n- Quantity Restrictions:\n    - Both legs must have the same quantity\n    - `ICEBERG` quantities however do not have to be the same\n- Order Rate Limit\n    - `OCO` counts as 2 orders against the order rate limit.\n    \nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query OCO (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/orderList?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "orderList"],
+              "query": [
+                {
+                  "key": "orderListId",
+                  "value": "",
+                  "description": "Order list id",
+                  "disabled": true
+                },
+                {
+                  "key": "origClientOrderId",
+                  "value": "",
+                  "description": "Order id from client",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Retrieves a specific OCO based on provided optional parameters\n\nWeight(IP): 2"
+          },
+          "response": []
+        },
+        {
+          "name": "Cancel OCO (TRADE)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/orderList?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "orderList"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "orderListId",
+                  "value": "",
+                  "description": "Order list id",
+                  "disabled": true
+                },
+                {
+                  "key": "listClientOrderId",
+                  "value": "",
+                  "description": "A unique Id for the entire orderList",
+                  "disabled": true
+                },
+                {
+                  "key": "newClientOrderId",
+                  "value": "",
+                  "description": "Used to uniquely identify this cancel. Automatically generated by default",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Cancel an entire Order List\n\nCanceling an individual leg will cancel the entire OCO\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query all OCO (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/allOrderList?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "allOrderList"],
+              "query": [
+                {
+                  "key": "fromId",
+                  "value": "",
+                  "description": "Trade id to fetch from. Default gets most recent trades.",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Retrieves all OCO based on provided optional parameters\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Open OCO (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/openOrderList?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "openOrderList"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 3"
+          },
+          "response": []
+        },
+        {
+          "name": "Account Information (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/account?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "account"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get current account information.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Account Trade List (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/myTrades?symbol=BNBUSDT&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "myTrades"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT"
+                },
+                {
+                  "key": "orderId",
+                  "value": "",
+                  "description": "This can only be used in combination with symbol.",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "fromId",
+                  "value": "",
+                  "description": "Trade id to fetch from. Default gets most recent trades.",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get trades for a specific account and symbol.\n\nIf `fromId` is set, it will get id >= that `fromId`. Otherwise most recent orders are returned.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Query Current Order Count Usage (TRADE)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/api/v3/rateLimit/order?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["api", "v3", "rateLimit", "order"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Displays the user's current order count usage for all intervals.\n\nWeight(IP): 20"
+          },
+          "response": []
+        }
+      ],
+      "description": "Account/Trade"
+    },
+    {
+      "name": "User Data Stream",
+      "item": [
+        {
+          "name": "Spot",
+          "item": [
+            {
+              "name": "Create a ListenKey (USER_STREAM)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/api/v3/userDataStream",
+                  "host": ["{{url}}"],
+                  "path": ["api", "v3", "userDataStream"]
+                },
+                "description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
+              },
+              "response": []
+            },
+            {
+              "name": "Ping/Keep-alive a ListenKey (USER_STREAM)",
+              "request": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/api/v3/userDataStream?listenKey=listen-key",
+                  "host": ["{{url}}"],
+                  "path": ["api", "v3", "userDataStream"],
+                  "query": [
+                    {
+                      "key": "listenKey",
+                      "value": "listen-key",
+                      "description": "User websocket listen key"
+                    }
+                  ]
+                },
+                "description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
+              },
+              "response": []
+            },
+            {
+              "name": "Close a ListenKey (USER_STREAM)",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/api/v3/userDataStream?listenKey=listen-key",
+                  "host": ["{{url}}"],
+                  "path": ["api", "v3", "userDataStream"],
+                  "query": [
+                    {
+                      "key": "listenKey",
+                      "value": "listen-key",
+                      "description": "User websocket listen key"
+                    }
+                  ]
+                },
+                "description": "Close out a user data stream.\n\nWeight: 1"
+              },
+              "response": []
+            }
+          ],
+          "description": "User Data Stream"
+        },
+        {
+          "name": "Cross Margin",
+          "item": [
+            {
+              "name": "Create a ListenKey (USER_STREAM)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/sapi/v1/userDataStream",
+                  "host": ["{{url}}"],
+                  "path": ["sapi", "v1", "userDataStream"]
+                },
+                "description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
+              },
+              "response": []
+            },
+            {
+              "name": "Ping/Keep-alive a ListenKey (USER_STREAM)",
+              "request": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/sapi/v1/userDataStream?listenKey=listen-key",
+                  "host": ["{{url}}"],
+                  "path": ["sapi", "v1", "userDataStream"],
+                  "query": [
+                    {
+                      "key": "listenKey",
+                      "value": "listen-key",
+                      "description": "User websocket listen key"
+                    }
+                  ]
+                },
+                "description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
+              },
+              "response": []
+            },
+            {
+              "name": "Close a ListenKey (USER_STREAM)",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/sapi/v1/userDataStream?listenKey=listen-key",
+                  "host": ["{{url}}"],
+                  "path": ["sapi", "v1", "userDataStream"],
+                  "query": [
+                    {
+                      "key": "listenKey",
+                      "value": "listen-key",
+                      "description": "User websocket listen key"
+                    }
+                  ]
+                },
+                "description": "Close out a user data stream.\n\nWeight: 1"
+              },
+              "response": []
+            }
+          ],
+          "description": "Margin User Data Stream"
+        },
+        {
+          "name": "Isolated Margin",
+          "item": [
+            {
+              "name": "Generate a Listen Key (USER_STREAM)",
+              "request": {
+                "method": "POST",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/sapi/v1/userDataStream/isolated?symbol=BTCUSDT",
+                  "host": ["{{url}}"],
+                  "path": ["sapi", "v1", "userDataStream", "isolated"],
+                  "query": [
+                    {
+                      "key": "symbol",
+                      "value": "BTCUSDT"
+                    }
+                  ]
+                },
+                "description": "Start a new user data stream.\nThe stream will close after 60 minutes unless a keepalive is sent. If the account has an active `listenKey`, that `listenKey` will be returned and its validity will be extended for 60 minutes.\n\nWeight: 1"
+              },
+              "response": []
+            },
+            {
+              "name": "Ping/Keep-alive a Listen Key (USER_STREAM)",
+              "request": {
+                "method": "PUT",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/sapi/v1/userDataStream/isolated?symbol=BTCUSDT&listenKey=listen-key",
+                  "host": ["{{url}}"],
+                  "path": ["sapi", "v1", "userDataStream", "isolated"],
+                  "query": [
+                    {
+                      "key": "symbol",
+                      "value": "BTCUSDT"
+                    },
+                    {
+                      "key": "listenKey",
+                      "value": "listen-key",
+                      "description": "User websocket listen key"
+                    }
+                  ]
+                },
+                "description": "Keepalive a user data stream to prevent a time out. User data streams will close after 60 minutes. It's recommended to send a ping about every 30 minutes.\n\nWeight: 1"
+              },
+              "response": []
+            },
+            {
+              "name": "Close a ListenKey (USER_STREAM)",
+              "request": {
+                "method": "DELETE",
+                "header": [
+                  {
+                    "key": "Content-Type",
+                    "type": "text",
+                    "value": "application/json"
+                  },
+                  {
+                    "key": "X-MBX-APIKEY",
+                    "value": "{{binance-api-key}}",
+                    "type": "text"
+                  }
+                ],
+                "url": {
+                  "raw": "{{url}}/sapi/v1/userDataStream/isolated?symbol=BTCUSDT&listenKey=listen-key",
+                  "host": ["{{url}}"],
+                  "path": ["sapi", "v1", "userDataStream", "isolated"],
+                  "query": [
+                    {
+                      "key": "symbol",
+                      "value": "BTCUSDT"
+                    },
+                    {
+                      "key": "listenKey",
+                      "value": "listen-key",
+                      "description": "User websocket listen key"
+                    }
+                  ]
+                },
+                "description": "Close out a user data stream.\n\nWeight: 1"
+              },
+              "response": []
+            }
+          ],
+          "description": "Isolated User Data Stream"
+        }
+      ],
+      "description": ""
+    },
+    {
+      "name": "Wallet",
+      "item": [
+        {
+          "name": "System Status (System)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/system/status",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "system", "status"]
+            },
+            "description": "Fetch system status.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "All Coins' Information (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/capital/config/getall?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "capital", "config", "getall"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get information of coins (available for deposit and withdraw) for user.\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Daily Account Snapshot (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/accountSnapshot?type=SPOT`&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "accountSnapshot"],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "SPOT",
+                  "description": "\"SPOT\", \"MARGIN\", \"FUTURES\""
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- The query time period must be less than 30 days\n- Support query within the last one month only\n- If startTimeand endTime not sent, return records of the last 7 days by default\n\nWeight(IP): 2400"
+          },
+          "response": []
+        },
+        {
+          "name": "Disable Fast Withdraw Switch (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/account/disableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "account", "disableFastWithdrawSwitch"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- This request will disable fastwithdraw switch under your account.\n- You need to enable \"trade\" option for the api key which requests this endpoint.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Enable Fast Withdraw Switch (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/account/enableFastWithdrawSwitch?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "account", "enableFastWithdrawSwitch"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- This request will enable fastwithdraw switch under your account. You need to enable \"trade\" option for the api key which requests this endpoint.\n- When Fast Withdraw Switch is on, transferring funds to a Binance account will be done instantly. There is no on-chain transaction, no transaction ID and no withdrawal fee.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Withdraw (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/capital/withdraw/apply?coin=BNB&address=&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "capital", "withdraw", "apply"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name"
+                },
+                {
+                  "key": "withdrawOrderId",
+                  "value": "",
+                  "description": "Client id for withdraw",
+                  "disabled": true
+                },
+                {
+                  "key": "network",
+                  "value": "",
+                  "description": "Get the value from `GET /sapi/v1/capital/config/getall`",
+                  "disabled": true
+                },
+                {
+                  "key": "address",
+                  "value": ""
+                },
+                {
+                  "key": "addressTag",
+                  "value": "",
+                  "description": "Secondary address identifier for coins like XRP,XMR etc.",
+                  "disabled": true
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "transactionFeeFlag",
+                  "value": "",
+                  "description": "When making internal transfer\n- `true` ->  returning the fee to the destination account;\n- `false` -> returning the fee back to the departure account.",
+                  "disabled": true
+                },
+                {
+                  "key": "name",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "walletType",
+                  "value": "",
+                  "description": "The wallet type for withdraw，0-Spot wallet, 1- Funding wallet. Default is Spot wallet",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Submit a withdraw request.\n\n- If `network` not send, return with default network of the coin.\n- You can get `network` and `isDefault` in `networkList` of a coin in the response of `Get /sapi/v1/capital/config/getall (HMAC SHA256)`.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Deposit History (supporting network) (User Data)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/capital/deposit/hisrec?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "capital", "deposit", "hisrec"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name",
+                  "disabled": true
+                },
+                {
+                  "key": "status",
+                  "value": "",
+                  "description": "* `0` - pending\n* `6` - credited but cannot withdraw\n* `1` - success",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch deposit history.\n\n- Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.\n- If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Withdraw History (supporting network) (User Data)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/capital/withdraw/history?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "capital", "withdraw", "history"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name",
+                  "disabled": true
+                },
+                {
+                  "key": "withdrawOrderId",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "status",
+                  "value": "",
+                  "description": "* `0` - Email Sent\n* `1` - Cancelled\n* `2` - Awaiting Approval\n* `3` - Rejected\n* `4` - Processing\n* `5` - Failure\n* `6` - Completed",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "offset",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "500",
+                  "description": "Default 500; max 1000.",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch withdraw history.\n\n- `network` may not be in the response for old withdraw.\n- Please notice the default `startTime` and `endTime` to make sure that time interval is within 0-90 days.\n- If both `startTime` and `endTime` are sent, time between `startTime` and `endTime` must be less than 90 days\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Deposit Address (supporting network) (User Data)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/capital/deposit/address?coin=BNB&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "capital", "deposit", "address"],
+              "query": [
+                {
+                  "key": "coin",
+                  "value": "BNB",
+                  "description": "Coin name"
+                },
+                {
+                  "key": "network",
+                  "value": "ETH",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch deposit address with network.\n\n- If network is not send, return with default network of the coin.\n- You can get network and isDefault in networkList in the response of Get /sapi/v1/capital/config/getall (HMAC SHA256).\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Account Status (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/account/status?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "account", "status"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch account status detail.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Account API Trading Status (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/account/apiTradingStatus?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "account", "apiTradingStatus"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch account API trading status with details.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "DustLog (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/dribblet?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "dribblet"],
+              "query": [
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Get Assets That Can Be Converted Into BNB (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/dust-btc?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "dust-btc"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Dust Transfer (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/dust?asset=&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "dust"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "",
+                  "description": "The asset being converted. For example, asset=BTC&asset=USDT"
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Convert dust assets to BNB.\n\nWeight(UID): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Asset Dividend Record (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/assetDividend?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "assetDividend"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "limit",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Query asset Dividend Record\n\nWeight(IP): 10"
+          },
+          "response": []
+        },
+        {
+          "name": "Asset Detail (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/assetDetail?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "assetDetail"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch details of assets supported on Binance.\n\n- Please get network and other deposit or withdraw details from `GET /sapi/v1/capital/config/getall`.\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Trade Fee (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/tradeFee?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "tradeFee"],
+              "query": [
+                {
+                  "key": "symbol",
+                  "value": "BNBUSDT",
+                  "description": "Trading symbol, e.g. BNBUSDT",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Fetch trade fee\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Query User Universal Transfer History (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/transfer?type=MAIN_UMFUTURE&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "transfer"],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "MAIN_UMFUTURE",
+                  "description": "Universal transfer type"
+                },
+                {
+                  "key": "startTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "endTime",
+                  "value": "",
+                  "description": "UTC timestamp in ms",
+                  "disabled": true
+                },
+                {
+                  "key": "current",
+                  "value": "1",
+                  "description": "Current querying page. Start from 1. Default:1",
+                  "disabled": true
+                },
+                {
+                  "key": "size",
+                  "value": "100",
+                  "description": "Default:10 Max:100",
+                  "disabled": true
+                },
+                {
+                  "key": "fromSymbol",
+                  "value": "BNBUSDT",
+                  "description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+                  "disabled": true
+                },
+                {
+                  "key": "toSymbol",
+                  "value": "BNBUSDT",
+                  "description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- Support query within the last 6 months only\n- If `startTime` and `endTime` not sent, return records of the last 7 days by default\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "User Universal Transfer (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/transfer?type=MAIN_UMFUTURE&asset=BTC&amount=1.01&timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "transfer"],
+              "query": [
+                {
+                  "key": "type",
+                  "value": "MAIN_UMFUTURE",
+                  "description": "Universal transfer type"
+                },
+                {
+                  "key": "asset",
+                  "value": "BTC"
+                },
+                {
+                  "key": "amount",
+                  "value": "1.01"
+                },
+                {
+                  "key": "fromSymbol",
+                  "value": "BNBUSDT",
+                  "description": "Must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+                  "disabled": true
+                },
+                {
+                  "key": "toSymbol",
+                  "value": "BNBUSDT",
+                  "description": "Must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "You need to enable `Permits Universal Transfer` option for the api key which requests this endpoint.\n\n- `fromSymbol` must be sent when type are ISOLATEDMARGIN_MARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n- `toSymbol` must be sent when type are MARGIN_ISOLATEDMARGIN and ISOLATEDMARGIN_ISOLATEDMARGIN\n\nENUM of transfer types:\n- MAIN_UMFUTURE Spot account transfer to USDⓈ-M Futures account\n- MAIN_CMFUTURE Spot account transfer to COIN-M Futures account\n- MAIN_MARGIN Spot account transfer to Margin（cross）account\n- UMFUTURE_MAIN USDⓈ-M Futures account transfer to Spot account\n- UMFUTURE_MARGIN USDⓈ-M Futures account transfer to Margin（cross）account\n- CMFUTURE_MAIN COIN-M Futures account transfer to Spot account\n- CMFUTURE_MARGIN COIN-M Futures account transfer to Margin(cross) account\n- MARGIN_MAIN Margin（cross）account transfer to Spot account\n- MARGIN_UMFUTURE Margin（cross）account transfer to USDⓈ-M Futures\n- MARGIN_CMFUTURE Margin（cross）account transfer to COIN-M Futures\n- ISOLATEDMARGIN_MARGIN Isolated margin account transfer to Margin(cross) account\n- MARGIN_ISOLATEDMARGIN Margin(cross) account transfer to Isolated margin account\n- ISOLATEDMARGIN_ISOLATEDMARGIN Isolated margin account transfer to Isolated margin account\n- MAIN_FUNDING Spot account transfer to Funding account\n- FUNDING_MAIN Funding account transfer to Spot account\n- FUNDING_UMFUTURE Funding account transfer to UMFUTURE account\n- UMFUTURE_FUNDING UMFUTURE account transfer to Funding account\n- MARGIN_FUNDING MARGIN account transfer to Funding account\n- FUNDING_MARGIN Funding account transfer to Margin account\n- FUNDING_CMFUTURE Funding account transfer to CMFUTURE account\n- CMFUTURE_FUNDING CMFUTURE account transfer to Funding account\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "Funding Wallet (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/asset/get-funding-asset?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "asset", "get-funding-asset"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "disabled": true
+                },
+                {
+                  "key": "needBtcValuation",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "- Currently supports querying the following business assets：Binance Pay, Binance Card, Binance Gift Card, Stock Token\n\nWeight(IP): 1"
+          },
+          "response": []
+        },
+        {
+          "name": "User Asset (USER_DATA)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v3/asset/getUserAsset?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v3", "asset", "getUserAsset"],
+              "query": [
+                {
+                  "key": "asset",
+                  "value": "BNB",
+                  "description": "If asset is blank, then query all positive assets user have.",
+                  "disabled": true
+                },
+                {
+                  "key": "needBtcValuation",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Get user assets, just for positive data.\n\nWeight(IP): 5"
+          },
+          "response": []
+        },
+        {
+          "name": "Get API Key Permission (USER_DATA)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Content-Type",
+                "type": "text",
+                "value": "application/json"
+              },
+              {
+                "key": "X-MBX-APIKEY",
+                "value": "{{binance-api-key}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{url}}/sapi/v1/account/apiRestrictions?timestamp={{timestamp}}&signature={{signature}}",
+              "host": ["{{url}}"],
+              "path": ["sapi", "v1", "account", "apiRestrictions"],
+              "query": [
+                {
+                  "key": "recvWindow",
+                  "value": "5000",
+                  "description": "The value cannot be greater than 60000",
+                  "disabled": true
+                },
+                {
+                  "key": "timestamp",
+                  "value": "{{timestamp}}",
+                  "description": "UTC timestamp in ms"
+                },
+                {
+                  "key": "signature",
+                  "value": "{{signature}}",
+                  "description": "Signature"
+                }
+              ]
+            },
+            "description": "Weight(IP): 1"
+          },
+          "response": []
+        }
+      ],
+      "description": "Wallet Endpoints"
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          "const ts  = Date.now();",
+          "pm.environment.set(\"timestamp\", ts);",
+          "",
+          "let paramsObject = {};",
+          "",
+          "const binance_api_secret = pm.environment.get(\"binance-api-secret\");",
+          "",
+          "const parameters = pm.request.url.query;",
+          "",
+          "parameters.map((param) => {",
+          "    if (param.key != 'signature' && ",
+          "        param.key != 'timestamp' && ",
+          "        !is_empty(param.value) &&",
+          "        !is_disabled(param.disabled)) {",
+          "            paramsObject[param.key] = param.value;",
+          "            //console.log(encodeURIComponent(param.value));",
+          "            //pm.environment.set(param.key, encodeURIComponent(param.value));",
+          "    }",
+          "})",
+          "        ",
+          "Object.assign(paramsObject, {'timestamp': ts});",
+          "",
+          "if (binance_api_secret) {",
+          "    const queryString = Object.keys(paramsObject).map((key) => {",
+          "        return `${key}=${paramsObject[key]}`;",
+          "    }).join('&');",
+          "    console.log(queryString);",
+          "    const signature = CryptoJS.HmacSHA256(queryString, binance_api_secret).toString();",
+          "    pm.environment.set(\"signature\", signature);",
+          "}",
+          "",
+          "",
+          "function is_disabled(str) {",
+          "    return str == true;",
+          "}",
+          "",
+          "function is_empty(str) {",
+          "    if (typeof str == 'undefined' ||",
+          "        !str || ",
+          "        str.length === 0 || ",
+          "        str === \"\" ||",
+          "        !/[^\\s]/.test(str) ||",
+          "        /^\\s*$/.test(str) ||",
+          "        str.replace(/\\s/g,\"\") === \"\")",
+          "    {",
+          "        return true;",
+          "    }",
+          "    else",
+          "    {",
+          "        return false;",
+          "    }",
+          "}"
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [""]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
Since the Wallet\Daily Account Snapshot does not have a value set for "type=", it can end up being confusing for new users of your collection. One has to read the documentation to find out that setting a value for "type=" is mandatory.

In addition, I also encountered oddities with the Postman UI that lead to unexpected "Signature for this request is not valid." errors when manually setting the "type=" value manually in the URL entry field:

![ss](https://user-images.githubusercontent.com/1854749/186537333-b4b72125-7398-490a-9795-383af17a67d3.gif)

As you can see above, the "type" parameter will be pushed to the bottom of the Params list, leading to the signature not being calculated correctly. This is because Postman does not send the parameters in order of the URL entry box, but in order of the Params list.