### PR TITLE
Added 'SPOT' to type on Daily Account Snapshot

### DIFF
--- a/collections/binance_spot_api_v1.postman_collection.json
+++ b/collections/binance_spot_api_v1.postman_collection.json
@@ -14579,7 +14579,7 @@
 							"query": [
 								{
 									"key": "type",
-									"value": "",
+									"value": "SPOT",
 									"description": "\"SPOT\", \"MARGIN\", \"FUTURES\""
 								},
 								{


### PR DESCRIPTION
Second attempt at creating this PR: Sorry, the previous commit had way too many changes! Please read below my explanation why I think "SPOT" should be provided as a default value for the type parameter on accountSnapshot. This is due to a bug in Postman.

---

Since the Wallet\Daily Account Snapshot does not have a value set for "type=", it can end up being confusing for new users of your collection. One has to read the documentation to find out that setting a value for "type=" is mandatory.

In addition, I also encountered oddities with the Postman UI that lead to unexpected "Signature for this request is not valid." errors when manually setting the "type=" value manually in the URL entry field:

![ss](https://user-images.githubusercontent.com/1854749/186537333-b4b72125-7398-490a-9795-383af17a67d3.gif)

As you can see above, the "type" parameter will be pushed to the bottom of the Params list, leading to the signature not being calculated correctly. This is because Postman does not send the parameters in order of the URL entry box, but in order of the Params list.