### PR TITLE
v1.8.0

### DIFF
--- a/collections/binance_delivery_future_api_v1.postman_collection.json
+++ b/collections/binance_delivery_future_api_v1.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "2ed379b6-03ac-4cec-b928-61e982e7c39a",
+		"_postman_id": "a7d81b74-fdd1-45b8-bd13-eb07e11ffd36",
 		"name": "Binance delivery futures API",
 		"description": "Binance official supported Postman collections.<br/>\n- API documents: https://binance-docs.github.io/apidocs/futures/en/\n- Telegram: https://t.me/binance_api_english\n- Open Issue at: https://github.com/binance-exchange/binance-api-postman",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "23566881"
 	},
 	"item": [
 		{
@@ -3101,6 +3102,68 @@
 								{
 									"key": "pair",
 									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Portfolio Margin Account Information",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"type": "text",
+								"value": "{{binance-api-key}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/dapi/v1/pmAccountInfo?asset=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"dapi",
+								"v1",
+								"pmAccountInfo"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
 								}
 							]
 						}

--- a/collections/binance_perpetual_future_api_v1.postman_collection.json
+++ b/collections/binance_perpetual_future_api_v1.postman_collection.json
@@ -1,9 +1,10 @@
 {
 	"info": {
-		"_postman_id": "a8b7c0a5-be90-42dc-b0b3-d64666563621",
+		"_postman_id": "78a56a4a-47e7-41ce-8c4f-0e3f0323165e",
 		"name": "Binance perpetual future API",
 		"description": "Binance official supported Postman collections.<br/>\n- API documents: https://binance-docs.github.io/apidocs/futures/en/\n- Telegram: https://t.me/binance_api_english\n- Open Issue at: https://github.com/binance-exchange/binance-api-postman",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "23566881"
 	},
 	"item": [
 		{
@@ -608,7 +609,7 @@
 								"fapi",
 								"v1",
 								"ticker",
-								"24hr"
+								"price"
 							],
 							"query": [
 								{
@@ -3292,6 +3293,68 @@
 								{
 									"key": "symbol",
 									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Portfolio Margin Account Information",
+					"event": [
+						{
+							"listen": "prerequest",
+							"script": {
+								"exec": [
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"name": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"type": "text",
+								"value": "{{binance-api-key}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/fapi/v1/pmAccountInfo?asset=&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"fapi",
+								"v1",
+								"pmAccountInfo"
+							],
+							"query": [
+								{
+									"key": "asset",
+									"value": ""
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000",
+									"description": "The value cannot be greater than 60000",
+									"disabled": true
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
 								}
 							]
 						}


### PR DESCRIPTION
### Added
*Portfolio Margin:*
GET /fapi/v1/pmAccountInfo: Get Portfolio Margin current account information.
GET /dapi/v1/pmAccountInfo: Get Portfolio Margin current account information.

### Fixed
*Market:*
GET /fapi/v1/ticker/price: Fixed the path. Previously the path was pointing to /fapi/v1/ticker/24hr.