### PR TITLE
v1.14.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 1.14.0 - 2023-12-12
+
+### Spot
+#### Add
+- `GET /api/v3/account/commission`
+- `GET /api/v3/ticker/tradingDay`
+- `GET /sapi/v1/margin/leverageBracket`
+- `GET /sapi/v1/capital/deposit/address/list`
+
+#### Update
+- `GET /api/v3/klines` and `GET /api/v3/uiKlines` have a new optional parameter timeZone.
+- `POST /api/v3/order/test` and `POST /api/v3/sor/order/test` have a new optional parameter computeCommissionRates.
+
+### UM Futures
+- Replace `GET /fapi/v1/ticker/price` by `GET /fapi/v2/ticker/price`
 
 ## 1.13.0 -2023-11-16
 

--- a/collections/Binance Spot API.postman_collection.json
+++ b/collections/Binance Spot API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "385fa3e1-9187-4ecd-8b67-5605b162dc79",
+		"_postman_id": "2e407d5e-b011-46cb-853a-538ffd42c797",
 		"name": "Binance Spot API",
 		"description": "Binance official supported Postman collections.<br/>\n- API documents: https://binance-docs.github.io/apidocs/spot/en/#change-log\n- Telegram: https://t.me/binance_api_english\n- Open Issue at: https://github.com/binance-exchange/binance-api-postman",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
@@ -8463,6 +8463,38 @@
 						"description": "Get tokens or symbols delist schedule for cross margin and isolated margin\n\nWeight(UID): 100"
 					},
 					"response": []
+				},
+				{
+					"name": "Query Liability Coin Leverage Bracket in Cross Margin Pro Mode(MARKET_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/margin/leverageBracket",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"margin",
+								"leverageBracket"
+							]
+						},
+						"description": ""
+					},
+					"response": []
 				}
 			],
 			"description": "Margin Account/Trade"
@@ -8797,6 +8829,11 @@
 									"disabled": true
 								},
 								{
+									"key": "timeZone",
+									"value": "",
+									"disabled": true
+								},
+								{
 									"key": "limit",
 									"value": "500",
 									"description": "Default 500; max 1000.",
@@ -8846,6 +8883,11 @@
 								},
 								{
 									"key": "endTime",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "timeZone",
 									"value": "",
 									"disabled": true
 								},
@@ -9069,6 +9111,58 @@
 							]
 						},
 						"description": "The window used to compute statistics is typically slightly wider than requested windowSize.\n\nopenTime for /api/v3/ticker always starts on a minute, while the closeTime is the current time of the request. As such, the effective window might be up to 1 minute wider than requested.\n\nE.g. If the closeTime is 1641287867099 (January 04, 2022 09:17:47:099 UTC) , and the windowSize is 1d. the openTime will be: 1641201420000 (January 3, 2022, 09:17:00 UTC)\n\nWeight(IP): 2 for each requested symbol regardless of windowSize.\n\nThe weight for this request will cap at 100 once the number of symbols in the request is more than 50."
+					},
+					"response": []
+				},
+				{
+					"name": "Trading Day Ticker",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/ticker/tradingDay?symbol=BNBUSDT",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"ticker",
+								"tradingDay"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BNBUSDT",
+									"description": "Trading symbol, e.g. BNBUSDT"
+								},
+								{
+									"key": "symbols",
+									"value": "",
+									"description": "Either symbol or symbols must be provided\nExamples of accepted format for the symbols parameter: [\"BTCUSDT\",\"BNBUSDT\"] or %5B%22BTCUSDT%22,%22BNBUSDT%22%5D.\n\nThe maximum number of symbols allowed in a request is 100.",
+									"disabled": true
+								},
+								{
+									"key": "timeZone",
+									"value": "",
+									"description": "0 (UTC)",
+									"disabled": true
+								},
+								{
+									"key": "type",
+									"value": "",
+									"description": "Supported values: FULL or MINI.\nIf none provided, the default is FULL",
+									"disabled": true
+								}
+							]
+						},
+						"description": ""
 					},
 					"response": []
 				}
@@ -14911,7 +15005,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/order/test?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/api/v3/order/test?symbol=BNBUSDT&side=SELL&type=&computeCommissionRates=true&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -15006,6 +15100,11 @@
 									"value": "5000",
 									"description": "The value cannot be greater than 60000",
 									"disabled": true
+								},
+								{
+									"key": "computeCommissionRates",
+									"value": "true",
+									"description": "Default: false"
 								},
 								{
 									"key": "timestamp",
@@ -16373,7 +16472,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/v3/sor/order/test?symbol=BNBUSDT&side=SELL&type=&timestamp={{timestamp}}&signature={{signature}}",
+							"raw": "{{url}}/api/v3/sor/order/test?symbol=BNBUSDT&side=SELL&type=&computeCommissionRates=true&timestamp={{timestamp}}&signature={{signature}}",
 							"host": [
 								"{{url}}"
 							],
@@ -16459,14 +16558,16 @@
 									"disabled": true
 								},
 								{
+									"key": "computeCommissionRates",
+									"value": "true"
+								},
+								{
 									"key": "timestamp",
-									"value": "{{timestamp}}",
-									"description": "Set the response JSON. MARKET and LIMIT order types default to FULL, all other orders default to ACK."
+									"value": "{{timestamp}}"
 								},
 								{
 									"key": "signature",
-									"value": "{{signature}}",
-									"description": "The value cannot be greater than 60000"
+									"value": "{{signature}}"
 								}
 							]
 						},
@@ -16543,6 +16644,57 @@
 							]
 						},
 						"description": "Get current account information.\n\nWeight(IP): 10"
+					},
+					"response": []
+				},
+				{
+					"name": "Query Commission Rates (USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/v3/account/commission?symbol=BTCUSDT&recvWindow=5000&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"v3",
+								"account",
+								"commission"
+							],
+							"query": [
+								{
+									"key": "symbol",
+									"value": "BTCUSDT"
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000"
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}",
+									"description": "Signature"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
+								}
+							]
+						},
+						"description": ""
 					},
 					"response": []
 				}
@@ -21631,6 +21783,63 @@
 						"description": "Apply deposit credit for expired address (One click arrival)\n\nParams need to be in the POST body\n\nWeight(IP): 1"
 					},
 					"response": []
+				},
+				{
+					"name": "Fetch deposit address list with network(USER_DATA)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"type": "text",
+								"value": "application/json"
+							},
+							{
+								"key": "X-MBX-APIKEY",
+								"value": "{{binance-api-key}}",
+								"type": "text"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/sapi/v1/capital/deposit/address/list?coin=BTC&recvWindow=5000&timestamp={{timestamp}}&signature={{signature}}",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"sapi",
+								"v1",
+								"capital",
+								"deposit",
+								"address",
+								"list"
+							],
+							"query": [
+								{
+									"key": "coin",
+									"value": "BTC"
+								},
+								{
+									"key": "network",
+									"value": "",
+									"disabled": true
+								},
+								{
+									"key": "recvWindow",
+									"value": "5000"
+								},
+								{
+									"key": "timestamp",
+									"value": "{{timestamp}}"
+								},
+								{
+									"key": "signature",
+									"value": "{{signature}}"
+								}
+							]
+						},
+						"description": ""
+					},
+					"response": []
 				}
 			],
 			"description": "Wallet Endpoints"
@@ -21771,7 +21980,7 @@
 								}
 							]
 						},
-						"description": "- If startTime and endTime are not sent, the recent 7-day data will be returned.\n- The max interval between startTime and endTime is 30 days.\n\nWeight(UID): 6000"
+						"description": ""
 					},
 					"response": []
 				},

--- a/collections/Binance USDs-M Futures API.postman_collection.json
+++ b/collections/Binance USDs-M Futures API.postman_collection.json
@@ -590,7 +590,7 @@
 					"response": []
 				},
 				{
-					"name": "Symbol Price Ticker",
+					"name": "Symbol Price Ticker V2",
 					"request": {
 						"method": "GET",
 						"header": [
@@ -601,13 +601,13 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/fapi/v1/ticker/price",
+							"raw": "{{url}}/fapi/v2/ticker/price",
 							"host": [
 								"{{url}}"
 							],
 							"path": [
 								"fapi",
-								"v1",
+								"v2",
 								"ticker",
 								"price"
 							],


### PR DESCRIPTION
### Spot
#### Add
- `GET /api/v3/account/commission`
- `GET /api/v3/ticker/tradingDay`
- `GET /sapi/v1/margin/leverageBracket`
- `GET /sapi/v1/capital/deposit/address/list`

#### Update
- `GET /api/v3/klines` and `GET /api/v3/uiKlines` have a new optional parameter timeZone.
- `POST /api/v3/order/test` and `POST /api/v3/sor/order/test` have a new optional parameter computeCommissionRates.

### UM Futures
- Replace `GET /fapi/v1/ticker/price` by `GET /fapi/v2/ticker/price`